### PR TITLE
[#16] Feature/Jpa Auditing 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,12 +25,22 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
 
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // database
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'org.postgresql:postgresql'
 
     // test
     testCompileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+    testRuntimeOnly 'com.h2database:h2'
 
     // test
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/depromeet/lessonfour/server/common/persist/jpa/JpaAuditingConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/common/persist/jpa/JpaAuditingConfig.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
-public class JpaAuditingConfig {
-}
+public class JpaAuditingConfig {}

--- a/src/main/java/depromeet/lessonfour/server/common/persist/jpa/JpaAuditingConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/common/persist/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package depromeet.lessonfour.server.common.persist.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntity.java
+++ b/src/main/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package depromeet.lessonfour.server.common.persist.jpa.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntity.java
+++ b/src/main/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntity.java
@@ -1,23 +1,24 @@
 package depromeet.lessonfour.server.common.persist.jpa.entity;
 
-import jakarta.persistence.*;
-import lombok.Getter;
+import java.time.LocalDateTime;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
+import lombok.Getter;
 
 @Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseTimeEntity {
 
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,26 @@
 spring:
   application:
     name: server
+  datasource:
+    url: ${ DB_URL:jdbc:postgresql://localhost:5432/lessonfour }
+    driver-class-name: org.postgresql.Driver
+    username: ${ DB_USERNAME:root }
+    password: ${ DB_PASSWORD:root }
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+jwt:
+  secret: mySecretKeyForJWTWhichShouldBeAtLeast256BitsLongToEnsureSecurityAndCompliance
+  expiration: 86400 # 24 hours
+
+logging:
+  level:
+    depromeet.lessonfour: DEBUG
+    org.springframework.security: DEBUG

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,10 +2,10 @@ spring:
   application:
     name: server
   datasource:
-    url: ${ DB_URL:jdbc:postgresql://localhost:5432/lessonfour }
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/lessonfour}
     driver-class-name: org.postgresql.Driver
-    username: ${ DB_USERNAME:root }
-    password: ${ DB_PASSWORD:root }
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:root}
 
   jpa:
     hibernate:

--- a/src/test/java/depromeet/lessonfour/server/api/HelloControllerE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/api/HelloControllerE2ETest.java
@@ -7,12 +7,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 
 import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
+@WithMockUser
 class HelloControllerE2ETest {
 
   @LocalServerPort private int port;

--- a/src/test/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntityTest.java
+++ b/src/test/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntityTest.java
@@ -1,8 +1,9 @@
 package depromeet.lessonfour.server.common.persist.jpa.entity;
 
-import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,92 +11,91 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 class BaseTimeEntityTest {
 
-    @Autowired
-    private EntityManager em;
+  @Autowired private EntityManager em;
 
-    @Entity
-    @Getter
-    @Setter
-    @Table(name = "test_entity")
-    static class TestEntity extends BaseTimeEntity {
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
-        
-        private String name;
-        
-        public TestEntity() {}
-        
-        public TestEntity(String name) {
-            this.name = name;
-        }
+  @Entity
+  @Getter
+  @Setter
+  @Table(name = "test_entity")
+  static class TestEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    public TestEntity() {}
+
+    public TestEntity(String name) {
+      this.name = name;
     }
+  }
 
-    @Test
-    @DisplayName("엔티티가 생성될 때 생성시간이 저장되어야 한다")
-    void givenTestEntity_whenSaved_thenCreatedTimeSaved() {
-        // given
-        TestEntity entity = new TestEntity("Test Name");
-        assertThat(entity.getCreatedAt()).isNull();
+  @Test
+  @DisplayName("엔티티가 생성될 때 생성시간이 저장되어야 한다")
+  void givenTestEntity_whenSaved_thenCreatedTimeSaved() {
+    // given
+    TestEntity entity = new TestEntity("Test Name");
+    assertThat(entity.getCreatedAt()).isNull();
 
-        // when
-        em.persist(entity);
-        em.flush();
-        em.clear();
+    // when
+    em.persist(entity);
+    em.flush();
+    em.clear();
 
-        // then
-        TestEntity saved = em.find(TestEntity.class, entity.getId());
-        assertThat(saved.getCreatedAt()).isNotNull();
-    }
+    // then
+    TestEntity saved = em.find(TestEntity.class, entity.getId());
+    assertThat(saved.getCreatedAt()).isNotNull();
+  }
 
-    @Test
-    @DisplayName("엔티티가 생성될 때 수정시간이 저장되어야 한다")
-    void givenTestEntity_whenSaved_thenUpdatedTimeSaved() {
-        // given
-        TestEntity entity = new TestEntity("Original Name");
-        assertThat(entity.getUpdatedAt()).isNull();
+  @Test
+  @DisplayName("엔티티가 생성될 때 수정시간이 저장되어야 한다")
+  void givenTestEntity_whenSaved_thenUpdatedTimeSaved() {
+    // given
+    TestEntity entity = new TestEntity("Original Name");
+    assertThat(entity.getUpdatedAt()).isNull();
 
-        // when
-        em.persist(entity);
-        em.flush();
-        em.clear();
+    // when
+    em.persist(entity);
+    em.flush();
+    em.clear();
 
-        // then
-        TestEntity saved = em.find(TestEntity.class, entity.getId());
-        assertThat(saved.getUpdatedAt()).isNotNull();
-    }
+    // then
+    TestEntity saved = em.find(TestEntity.class, entity.getId());
+    assertThat(saved.getUpdatedAt()).isNotNull();
+  }
 
-    @Test
-    @DisplayName("엔티티가 수정될 때 수정시간이 갱신되어야 한다")
-    void givenTestEntity_whenUpdated_thenUpdatedTimeChange() throws InterruptedException {
-        // given
-        TestEntity entity = new TestEntity("Original Name");
-        em.persist(entity);
-        em.flush();
-        em.clear();
+  @Test
+  @DisplayName("엔티티가 수정될 때 수정시간이 갱신되어야 한다")
+  void givenTestEntity_whenUpdated_thenUpdatedTimeChange() throws InterruptedException {
+    // given
+    TestEntity entity = new TestEntity("Original Name");
+    em.persist(entity);
+    em.flush();
+    em.clear();
 
-        TestEntity original = em.find(TestEntity.class, entity.getId());
-        LocalDateTime originalUpdatedAt = original.getUpdatedAt();
+    TestEntity original = em.find(TestEntity.class, entity.getId());
+    LocalDateTime originalUpdatedAt = original.getUpdatedAt();
 
-        // when
-        Thread.sleep(10);
-        original.setName("Changed Name");
-        em.flush();
-        em.clear();
+    // when
+    Thread.sleep(10);
+    original.setName("Changed Name");
+    em.flush();
+    em.clear();
 
-        TestEntity changed = em.find(TestEntity.class, entity.getId());
-        LocalDateTime changedUpdatedAt = changed.getUpdatedAt();
+    TestEntity changed = em.find(TestEntity.class, entity.getId());
+    LocalDateTime changedUpdatedAt = changed.getUpdatedAt();
 
-        // then
-        assertThat(changedUpdatedAt).isNotEqualTo(originalUpdatedAt);
-    }
+    // then
+    assertThat(changedUpdatedAt).isNotEqualTo(originalUpdatedAt);
+  }
 }

--- a/src/test/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntityTest.java
+++ b/src/test/java/depromeet/lessonfour/server/common/persist/jpa/entity/BaseTimeEntityTest.java
@@ -1,0 +1,101 @@
+package depromeet.lessonfour.server.common.persist.jpa.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class BaseTimeEntityTest {
+
+    @Autowired
+    private EntityManager em;
+
+    @Entity
+    @Getter
+    @Setter
+    @Table(name = "test_entity")
+    static class TestEntity extends BaseTimeEntity {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+        
+        private String name;
+        
+        public TestEntity() {}
+        
+        public TestEntity(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    @DisplayName("엔티티가 생성될 때 생성시간이 저장되어야 한다")
+    void givenTestEntity_whenSaved_thenCreatedTimeSaved() {
+        // given
+        TestEntity entity = new TestEntity("Test Name");
+        assertThat(entity.getCreatedAt()).isNull();
+
+        // when
+        em.persist(entity);
+        em.flush();
+        em.clear();
+
+        // then
+        TestEntity saved = em.find(TestEntity.class, entity.getId());
+        assertThat(saved.getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("엔티티가 생성될 때 수정시간이 저장되어야 한다")
+    void givenTestEntity_whenSaved_thenUpdatedTimeSaved() {
+        // given
+        TestEntity entity = new TestEntity("Original Name");
+        assertThat(entity.getUpdatedAt()).isNull();
+
+        // when
+        em.persist(entity);
+        em.flush();
+        em.clear();
+
+        // then
+        TestEntity saved = em.find(TestEntity.class, entity.getId());
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("엔티티가 수정될 때 수정시간이 갱신되어야 한다")
+    void givenTestEntity_whenUpdated_thenUpdatedTimeChange() throws InterruptedException {
+        // given
+        TestEntity entity = new TestEntity("Original Name");
+        em.persist(entity);
+        em.flush();
+        em.clear();
+
+        TestEntity original = em.find(TestEntity.class, entity.getId());
+        LocalDateTime originalUpdatedAt = original.getUpdatedAt();
+
+        // when
+        Thread.sleep(10);
+        original.setName("Changed Name");
+        em.flush();
+        em.clear();
+
+        TestEntity changed = em.find(TestEntity.class, entity.getId());
+        LocalDateTime changedUpdatedAt = changed.getUpdatedAt();
+
+        // then
+        assertThat(changedUpdatedAt).isNotEqualTo(originalUpdatedAt);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -3,11 +3,15 @@ spring:
     url: jdbc:h2:mem:testdb
     driver-class-name: org.h2.Driver
     username: sa
-    password:
+    password: ""
   jpa:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
 
 logging:
   level:


### PR DESCRIPTION
## Related Issue 🔗
#16 JWT 및 refresh token 관련 security configuration
- closes #번호

## Summary 📝
* spring security, postgresql 의존성 추가
* JpaAuditing 설정 추가
* createdAt, updatedAt 컬럼을 가지는 BaseTimeEntity 추가

## Changes ✨
- **의존성 추가**
  - `spring-boot-starter-data-jpa` + auditing 관련 설정
  - H2/PostgreSQL 드라이버
- **설정**
  - `JpaAuditingConfig` 추가 (`@EnableJpaAuditing`)
  - `application.yaml`에 DB 및 JPA 관련 설정 추가
- **공통 엔티티**
  - `BaseTimeEntity` (공통 `createdAt`, `updatedAt` 필드)

## Why we need 💡
- 모든 엔티티에서 생성 및 수정 시간을 일관성 있게 관리
- JPA Auditing으로 자동화 → 개발 생산성 및 유지보수성 향상

## Test 🧪
- `BaseTimeEntityTest`
  - 엔티티 저장 시 `createdAt`, `updatedAt` 값 자동 저장 확인
  - 엔티티 수정 시 `updatedAt` 값이 갱신되는지 확인

## Trouble Shooting 🐛
- `Thread.sleep`을 사용하여 `updatedAt` 변경 검증 (ms 단위 저장 시점 차이 고려)

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
X

## CC 👥
X

## Anything else? 💬
X