### PR TITLE
Feat/생활 기록 API 문서 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     // Swagger(OpenAPI) 공통
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'\
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
 }
 
 test {

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
@@ -1,7 +1,6 @@
 package depromeet.lessonfour.server.activityrecords.controllers;
 
 import java.time.LocalDate;
-import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -55,7 +54,7 @@ public class ActivityRecordsController {
       })
   @PatchMapping("/{activity-record-id}")
   public SuccessResponse<?> updateActivityRecord(
-      @PathVariable("activity-record-id") UUID activityRecordId,
+      @PathVariable("activity-record-id") Long activityRecordId,
       @RequestBody @Valid UpdateActivityRecordsRequest dto) {
     return SuccessResponse.of(SuccessCode.SUCCESS_UPDATE);
   }
@@ -68,7 +67,7 @@ public class ActivityRecordsController {
       })
   @DeleteMapping("/{activity-record-id}")
   public SuccessResponse<?> deleteActivityRecord(
-      @PathVariable("activity-record-id") UUID activityRecordId) {
+      @PathVariable("activity-record-id") Long activityRecordId) {
     return SuccessResponse.of(SuccessCode.SUCCESS_DELETE);
   }
 

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
@@ -20,8 +20,7 @@ import depromeet.lessonfour.server.activityrecords.schemas.response.GetActivityR
 import depromeet.lessonfour.server.common.exception.code.SuccessCode;
 import depromeet.lessonfour.server.common.exception.schemas.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,12 +31,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ActivityRecordsController {
 
-  @Operation(summary = "생활 기록 생성", description = "새로운 생활 기록을 생성합니다.")
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "201", description = "생활 기록 생성 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-      })
+  @Operation(
+      summary = "생활 기록 생성",
+      description = "새로운 생활 기록을 생성합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public SuccessResponse<?> createActivityRecord(
@@ -45,13 +42,10 @@ public class ActivityRecordsController {
     return SuccessResponse.of(SuccessCode.SUCCESS_CREATE);
   }
 
-  @Operation(summary = "생활 기록 수정", description = "기존 생활 기록을 수정합니다. 없던 음식은 추가됩니다.")
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "200", description = "생활 기록 수정 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 생활 기록"),
-      })
+  @Operation(
+      summary = "생활 기록 수정",
+      description = "기존 생활 기록을 수정합니다. 없던 음식은 추가됩니다.",
+      security = {@SecurityRequirement(name = "JWT")})
   @PatchMapping("/{activity-record-id}")
   public SuccessResponse<?> updateActivityRecord(
       @PathVariable("activity-record-id") Long activityRecordId,
@@ -59,25 +53,20 @@ public class ActivityRecordsController {
     return SuccessResponse.of(SuccessCode.SUCCESS_UPDATE);
   }
 
-  @Operation(summary = "생활 기록 삭제", description = "기존 생활 기록을 삭제합니다.")
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "200", description = "생활 기록 삭제 성공"),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 생활 기록"),
-      })
+  @Operation(
+      summary = "생활 기록 삭제",
+      description = "기존 생활 기록을 삭제합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
   @DeleteMapping("/{activity-record-id}")
   public SuccessResponse<?> deleteActivityRecord(
       @PathVariable("activity-record-id") Long activityRecordId) {
     return SuccessResponse.of(SuccessCode.SUCCESS_DELETE);
   }
 
-  @Operation(summary = "생활 기록 조회", description = "기존 생활 기록을 조회합니다.")
-  @ApiResponses(
-      value = {
-        @ApiResponse(responseCode = "200", description = "생활 기록 조회 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 날짜 형식"),
-        @ApiResponse(responseCode = "404", description = "해당 날짜의 생활 기록이 없음"),
-      })
+  @Operation(
+      summary = "생활 기록 조회",
+      description = "기존 생활 기록을 조회합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
   @GetMapping
   public SuccessResponse<GetActivityRecordsResponse> getActivityRecord(
       @RequestParam(required = true) LocalDate date) {

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
@@ -1,0 +1,84 @@
+package depromeet.lessonfour.server.activityrecords.controllers;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import depromeet.lessonfour.server.activityrecords.schemas.request.CreateActivityRecordsRequest;
+import depromeet.lessonfour.server.activityrecords.schemas.request.UpdateActivityRecordsRequest;
+import depromeet.lessonfour.server.activityrecords.schemas.response.GetActivityRecordsResponse;
+import depromeet.lessonfour.server.common.exception.code.SuccessCode;
+import depromeet.lessonfour.server.common.exception.schemas.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "생활 기록", description = "생활 기록에 대한 API 문서입니다.")
+@RestController
+@RequestMapping("/api/v1/activity-records")
+@RequiredArgsConstructor
+public class ActivityRecordsController {
+
+  @Operation(summary = "생활 기록 생성", description = "새로운 생활 기록을 생성합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "201", description = "생활 기록 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+      })
+  @PostMapping
+  public SuccessResponse<?> createActivityRecord(
+      @RequestBody @Valid CreateActivityRecordsRequest dto) {
+    return SuccessResponse.of(SuccessCode.SUCCESS_CREATE);
+  }
+
+  @Operation(summary = "생활 기록 수정", description = "기존 생활 기록을 수정합니다. 없던 음식은 추가됩니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "생활 기록 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 생활 기록"),
+      })
+  @PatchMapping("/{activity-record-id}")
+  public SuccessResponse<?> updateActivityRecord(
+      @PathVariable("activity-record-id") UUID activityRecordId,
+      @RequestBody @Valid UpdateActivityRecordsRequest dto) {
+    return SuccessResponse.of(SuccessCode.SUCCESS_UPDATE);
+  }
+
+  @Operation(summary = "생활 기록 삭제", description = "기존 생활 기록을 삭제합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "생활 기록 삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 생활 기록"),
+      })
+  @DeleteMapping("/{activity-record-id}")
+  public SuccessResponse<?> deleteActivityRecord(
+      @PathVariable("activity-record-id") UUID activityRecordId) {
+    return SuccessResponse.of(SuccessCode.SUCCESS_DELETE);
+  }
+
+  @Operation(summary = "생활 기록 조회", description = "기존 생활 기록을 조회합니다.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "생활 기록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 날짜 형식"),
+        @ApiResponse(responseCode = "404", description = "해당 날짜의 생활 기록이 없음"),
+      })
+  @GetMapping
+  public SuccessResponse<GetActivityRecordsResponse> getActivityRecord(
+      @RequestParam(required = true) LocalDate date) {
+    return SuccessResponse.of(null);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/controllers/ActivityRecordsController.java
@@ -3,6 +3,7 @@ package depromeet.lessonfour.server.activityrecords.controllers;
 import java.time.LocalDate;
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import depromeet.lessonfour.server.activityrecords.schemas.request.CreateActivityRecordsRequest;
@@ -37,6 +39,7 @@ public class ActivityRecordsController {
         @ApiResponse(responseCode = "201", description = "생활 기록 생성 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
       })
+  @ResponseStatus(HttpStatus.CREATED)
   @PostMapping
   public SuccessResponse<?> createActivityRecord(
       @RequestBody @Valid CreateActivityRecordsRequest dto) {

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/ActivityRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/ActivityRecord.java
@@ -1,7 +1,6 @@
 package depromeet.lessonfour.server.activityrecords.domain.entities;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 import depromeet.lessonfour.server.common.entities.BaseTimeEntity;
 import depromeet.lessonfour.server.users.domain.entities.User;
@@ -35,8 +34,8 @@ import lombok.NoArgsConstructor;
 public class ActivityRecord extends BaseTimeEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  private UUID id;
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
   // 작성자
   @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/Food.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/Food.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.activityrecords.domain.entities;
 
-import java.util.UUID;
-
 import depromeet.lessonfour.server.common.entities.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,8 +23,8 @@ import lombok.NoArgsConstructor;
 public class Food extends BaseTimeEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  private UUID id;
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
   @Column(nullable = false)
   @NotNull private String name;

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/FoodRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/domain/entities/FoodRecord.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.activityrecords.domain.entities;
 
-import java.util.UUID;
-
 import depromeet.lessonfour.server.common.entities.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -29,8 +27,8 @@ import lombok.NoArgsConstructor;
 public class FoodRecord extends BaseTimeEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  private UUID id;
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "activity_record_id", nullable = false)

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -1,14 +1,12 @@
 package depromeet.lessonfour.server.activityrecords.schemas.request;
 
-import java.util.List;
-import java.util.UUID;
-
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
 
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> foods,
@@ -16,6 +14,6 @@ public record CreateActivityRecordsRequest(
     @NotNull StressLevel stressLevel) {
 
   public record CreateFoodRequestDto(
-      @NotBlank(message = "음식 id는 필수입니다") UUID foodId,
+      @NotNull(message = "음식 id는 필수입니다") UUID foodId,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -10,10 +10,10 @@ import jakarta.validation.constraints.NotNull;
 
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> foods,
-    @NotNull int waterIntakeCups,
+    int waterIntakeCups,
     @NotNull StressLevel stressLevel) {
 
   public record CreateFoodRequestDto(
-      @NotBlank(message = "음식 이름을 필수입니다") String name,
+      @NotBlank(message = "음식 이름은 필수입니다") String name,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -1,19 +1,24 @@
 package depromeet.lessonfour.server.activityrecords.schemas.request;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
-import java.util.UUID;
 
 public record CreateActivityRecordsRequest(
-    @Valid List<CreateFoodRequestDto> foods,
-    @Min(0) int waterIntakeCups,
-    @NotNull StressLevel stressLevel) {
+    @Valid List<CreateFoodRequestDto> selectedFoods,
+    @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int selectedWater,
+    @NotNull(message = "스트레스 지수는 필수입니다") StressLevel selectedStress,
+    @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+        LocalDateTime selectedWhen) {
 
   public record CreateFoodRequestDto(
-      @NotNull(message = "음식 id는 필수입니다") UUID foodId,
-      @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
+      @NotNull(message = "음식 id는 필수입니다") Long foodId,
+      @NotNull(message = "식사 시간은 필수입니다") MealTime time) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -5,12 +5,13 @@ import java.util.List;
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> foods,
-    int waterIntakeCups,
+    @Min(0) int waterIntakeCups,
     @NotNull StressLevel stressLevel) {
 
   public record CreateFoodRequestDto(

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -1,0 +1,19 @@
+package depromeet.lessonfour.server.activityrecords.schemas.request;
+
+import java.util.List;
+
+import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
+import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateActivityRecordsRequest(
+    @Valid List<CreateFoodRequestDto> foods,
+    @NotNull int waterIntakeCups,
+    @NotNull StressLevel stressLevel) {
+
+  public record CreateFoodRequestDto(
+      @NotBlank(message = "음식 이름을 필수입니다") String name,
+      @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
+}

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -1,6 +1,7 @@
 package depromeet.lessonfour.server.activityrecords.schemas.request;
 
 import java.util.List;
+import java.util.UUID;
 
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
@@ -15,6 +16,6 @@ public record CreateActivityRecordsRequest(
     @NotNull StressLevel stressLevel) {
 
   public record CreateFoodRequestDto(
-      @NotBlank(message = "음식 이름은 필수입니다") String name,
+      @NotBlank(message = "음식 id는 필수입니다") UUID foodId,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/CreateActivityRecordsRequest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
+import depromeet.lessonfour.server.common.annotation.ValidEnum;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -14,11 +15,13 @@ import jakarta.validation.constraints.NotNull;
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> selectedFoods,
     @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int selectedWater,
-    @NotNull(message = "스트레스 지수는 필수입니다") StressLevel selectedStress,
+    @NotNull(message = "스트레스 지수는 필수입니다") @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
+        StressLevel selectedStress,
     @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
         LocalDateTime selectedWhen) {
 
   public record CreateFoodRequestDto(
       @NotNull(message = "음식 id는 필수입니다") Long foodId,
-      @NotNull(message = "식사 시간은 필수입니다") MealTime time) {}
+      @NotNull(message = "식사 시간은 필수입니다") @ValidEnum(enumClass = MealTime.class, message = "유효하지 않은 식사시간입니다.")
+          MealTime time) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -1,19 +1,24 @@
 package depromeet.lessonfour.server.activityrecords.schemas.request;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
-import java.util.UUID;
 
 public record UpdateActivityRecordsRequest(
     @Valid List<UpdateFoodRequestDto> foods,
-    @Min(0) int waterIntakeCups,
-    @NotNull StressLevel stressLevel) {
+    @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int selectedWater,
+    @NotNull(message = "스트레스 지수는 필수입니다") StressLevel selectedStress,
+    @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
+        LocalDateTime selectedWhen) {
 
   public record UpdateFoodRequestDto(
-      @NotNull(message = "음식 id는 필수입니다") UUID foodId,
+      @NotNull(message = "음식 id는 필수입니다") Long foodId,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -16,7 +16,6 @@ public record UpdateActivityRecordsRequest(
     @NotNull StressLevel stressLevel) {
 
   public record UpdateFoodRequestDto(
-      UUID id,
-      @NotBlank(message = "음식 이름은 필수입니다") String name,
+      @NotBlank(message = "음식 id는 필수입니다") UUID foodId,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -7,18 +7,21 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
+import depromeet.lessonfour.server.common.annotation.ValidEnum;
+import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateActivityRecordsRequest(
-    @Valid List<UpdateFoodRequestDto> foods,
-    @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int selectedWater,
-    @NotNull(message = "스트레스 지수는 필수입니다") StressLevel selectedStress,
-    @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX")
-        LocalDateTime selectedWhen) {
+    @Nullable @Valid List<UpdateFoodRequestDto> foods,
+    @Nullable @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") Integer selectedWater,
+    @Nullable @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
+        StressLevel selectedStress,
+    @Nullable @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS") LocalDateTime selectedWhen) {
 
   public record UpdateFoodRequestDto(
       @NotNull(message = "음식 id는 필수입니다") Long foodId,
-      @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
+      @NotNull(message = "식사 시간은 필수입니다") @ValidEnum(enumClass = MealTime.class, message = "유효하지 않은 식사시간입니다.")
+          MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -1,14 +1,12 @@
 package depromeet.lessonfour.server.activityrecords.schemas.request;
 
-import java.util.List;
-import java.util.UUID;
-
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
 
 public record UpdateActivityRecordsRequest(
     @Valid List<UpdateFoodRequestDto> foods,
@@ -16,6 +14,6 @@ public record UpdateActivityRecordsRequest(
     @NotNull StressLevel stressLevel) {
 
   public record UpdateFoodRequestDto(
-      @NotBlank(message = "음식 id는 필수입니다") UUID foodId,
+      @NotNull(message = "음식 id는 필수입니다") UUID foodId,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -6,12 +6,13 @@ import java.util.UUID;
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateActivityRecordsRequest(
     @Valid List<UpdateFoodRequestDto> foods,
-    int waterIntakeCups,
+    @Min(0) int waterIntakeCups,
     @NotNull StressLevel stressLevel) {
 
   public record UpdateFoodRequestDto(

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -1,0 +1,21 @@
+package depromeet.lessonfour.server.activityrecords.schemas.request;
+
+import java.util.List;
+import java.util.UUID;
+
+import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
+import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateActivityRecordsRequest(
+    @Valid List<UpdateFoodRequestDto> foods,
+    int waterIntakeCups,
+    @NotNull StressLevel stressLevel) {
+
+  public record UpdateFoodRequestDto(
+      UUID id,
+      @NotBlank(message = "음식 이름을 필수입니다") String name,
+      @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
+}

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/request/UpdateActivityRecordsRequest.java
@@ -16,6 +16,6 @@ public record UpdateActivityRecordsRequest(
 
   public record UpdateFoodRequestDto(
       UUID id,
-      @NotBlank(message = "음식 이름을 필수입니다") String name,
+      @NotBlank(message = "음식 이름은 필수입니다") String name,
       @NotNull(message = "식사 시간은 필수입니다") MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/response/GetActivityRecordsResponse.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/response/GetActivityRecordsResponse.java
@@ -2,17 +2,16 @@ package depromeet.lessonfour.server.activityrecords.schemas.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
 import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
 
 public record GetActivityRecordsResponse(
-    UUID id,
+    Long id,
     int waterIntakeCups,
     StressLevel stressLevel,
     List<FoodResponse> foods,
     LocalDateTime createdAt) {
 
-  public record FoodResponse(UUID id, String name, MealTime mealTime) {}
+  public record FoodResponse(Long id, String name, MealTime mealTime) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/response/GetActivityRecordsResponse.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecords/schemas/response/GetActivityRecordsResponse.java
@@ -1,0 +1,18 @@
+package depromeet.lessonfour.server.activityrecords.schemas.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import depromeet.lessonfour.server.activityrecords.domain.entities.MealTime;
+import depromeet.lessonfour.server.activityrecords.domain.entities.StressLevel;
+
+public record GetActivityRecordsResponse(
+    UUID id,
+    int waterIntakeCups,
+    StressLevel stressLevel,
+    List<FoodResponse> foods,
+    LocalDateTime createdAt) {
+
+  public record FoodResponse(UUID id, String name, MealTime mealTime) {}
+}

--- a/src/main/java/depromeet/lessonfour/server/api/EchoController.java
+++ b/src/main/java/depromeet/lessonfour/server/api/EchoController.java
@@ -6,6 +6,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
 @RestController
 @RequestMapping("/api/v1/echo")
 public class EchoController {

--- a/src/main/java/depromeet/lessonfour/server/api/HealthCheckController.java
+++ b/src/main/java/depromeet/lessonfour/server/api/HealthCheckController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
 @RestController
 @RequestMapping("/api/v1/health")
 public class HealthCheckController {

--- a/src/main/java/depromeet/lessonfour/server/auth/security/config/SecurityConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/security/config/SecurityConfig.java
@@ -98,6 +98,7 @@ public class SecurityConfig {
                         "/api/v1/health",
                         "/api/v1/auth/signup",
                         "/api/v1/auth/refresh",
+                        "/api/v1/activity-records/**",
                         "/api/v1/auth/kakao/**")
                     .permitAll()
                     .anyRequest()

--- a/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenGenerator.java
@@ -60,7 +60,7 @@ public class JwtTokenGenerator {
   }
 
   public String generateAccessToken(
-      UUID userId, String email, String nickname, Instant expiration) {
+      Long userId, String email, String nickname, Instant expiration) {
     return Jwts.builder()
         .subject(String.valueOf(userId))
         .issuedAt(new Date())

--- a/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenValidator.java
@@ -67,8 +67,8 @@ public class JwtTokenValidator {
   }
 
   /** JWT 토큰에서 Subject (사용자 ID) 추출 */
-  public Long extractSubject(String token) {
+  public String extractSubject(String token) {
     Claims claims = parseTokenClaims(token);
-    return Long.parseLong(claims.getSubject());
+    return claims.getSubject();
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenValidator.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenValidator.java
@@ -67,8 +67,8 @@ public class JwtTokenValidator {
   }
 
   /** JWT 토큰에서 Subject (사용자 ID) 추출 */
-  public String extractSubject(String token) {
+  public Long extractSubject(String token) {
     Claims claims = parseTokenClaims(token);
-    return claims.getSubject();
+    return Long.parseLong(claims.getSubject());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/auth/security/userdetails/AccountContext.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/security/userdetails/AccountContext.java
@@ -3,7 +3,6 @@ package depromeet.lessonfour.server.auth.security.userdetails;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -20,7 +19,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccountContext implements UserDetails {
 
-  private UUID id;
+  private Long id;
   private String email;
   private String password;
   private String nickname;

--- a/src/main/java/depromeet/lessonfour/server/auth/service/RefreshTokenUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/service/RefreshTokenUseCase.java
@@ -24,8 +24,8 @@ public class RefreshTokenUseCase {
   public AuthTokenDto refresh(String refreshToken) {
     validateRefreshToken(refreshToken);
 
-    Long userId = jwtTokenValidator.extractSubject(refreshToken);
-    User user = findUserById(userId);
+    String userId = jwtTokenValidator.extractSubject(refreshToken);
+    User user = findUserById(Long.valueOf(userId));
     compareWithStoredToken(user, refreshToken);
 
     return generateNewToken(user);

--- a/src/main/java/depromeet/lessonfour/server/auth/service/RefreshTokenUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/service/RefreshTokenUseCase.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.auth.service;
 
-import java.util.UUID;
-
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +24,7 @@ public class RefreshTokenUseCase {
   public AuthTokenDto refresh(String refreshToken) {
     validateRefreshToken(refreshToken);
 
-    String userId = jwtTokenValidator.extractSubject(refreshToken);
+    Long userId = jwtTokenValidator.extractSubject(refreshToken);
     User user = findUserById(userId);
     compareWithStoredToken(user, refreshToken);
 
@@ -41,15 +39,9 @@ public class RefreshTokenUseCase {
     }
   }
 
-  private User findUserById(String userId) {
-    final UUID uuid;
-    try {
-      uuid = UUID.fromString(userId);
-    } catch (IllegalArgumentException e) {
-      throw new BadCredentialsException("Invalid refresh token subject");
-    }
+  private User findUserById(Long userId) {
     return userRepository
-        .findById(uuid)
+        .findById(userId)
         .orElseThrow(() -> new BadCredentialsException("User not found"));
   }
 

--- a/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
@@ -7,11 +7,18 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 
 import depromeet.lessonfour.server.common.swagger.annotation.DisableSwaggerSecurity;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
@@ -72,73 +79,54 @@ public class SwaggerConfig {
         operation.setSecurity(Collections.emptyList());
       }
 
+      boolean isSecured = operation.getSecurity() != null && !operation.getSecurity().isEmpty();
+
       // 공통 응답 스키마 적용
-      addCommonResponses(operation);
+      addCommonResponses(operation, isSecured);
 
       return operation;
     };
   }
 
-  private void addCommonResponses(io.swagger.v3.oas.models.Operation operation) {
+  private void addCommonResponses(Operation operation, boolean isSecured) {
     if (operation.getResponses() == null) {
-      operation.setResponses(new io.swagger.v3.oas.models.responses.ApiResponses());
+      operation.setResponses(new ApiResponses());
     }
 
-    // 400 Bad Request - 잘못된 요청
-    if (!operation.getResponses().containsKey("400")) {
-      operation.getResponses().addApiResponse("400", createErrorResponse("잘못된 요청입니다.", "400"));
-    }
+    addResponseIfMissing(operation, HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", false, isSecured);
+    addResponseIfMissing(operation, HttpStatus.UNAUTHORIZED, "인증이 필요합니다.", true, isSecured);
+    addResponseIfMissing(operation, HttpStatus.FORBIDDEN, "접근 권한이 없습니다.", true, isSecured);
+    addResponseIfMissing(
+        operation, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", false, isSecured);
+  }
 
-    // 401 Unauthorized - 인증 실패 (보안이 필요한 엔드포인트만)
-    if (operation.getSecurity() != null
-        && !operation.getSecurity().isEmpty()
-        && !operation.getResponses().containsKey("401")) {
-      operation.getResponses().addApiResponse("401", createErrorResponse("인증이 필요합니다.", "401"));
-    }
+  private void addResponseIfMissing(
+      Operation operation,
+      HttpStatus status,
+      String message,
+      boolean securedOnly,
+      boolean isSecured) {
 
-    // 403 Forbidden - 권한 없음 (보안이 필요한 엔드포인트만)
-    if (operation.getSecurity() != null
-        && !operation.getSecurity().isEmpty()
-        && !operation.getResponses().containsKey("403")) {
-      operation.getResponses().addApiResponse("403", createErrorResponse("접근 권한이 없습니다.", "403"));
-    }
+    String code = String.valueOf(status.value());
 
-    // 500 Internal Server Error - 서버 오류
-    if (!operation.getResponses().containsKey("500")) {
-      operation
-          .getResponses()
-          .addApiResponse("500", createErrorResponse("서버 내부 오류가 발생했습니다.", "500"));
+    if ((!securedOnly || isSecured) && !operation.getResponses().containsKey(code)) {
+      operation.getResponses().addApiResponse(code, createErrorResponse(status, message));
     }
   }
 
-  private io.swagger.v3.oas.models.responses.ApiResponse createErrorResponse(
-      String description, String status) {
-    io.swagger.v3.oas.models.responses.ApiResponse response =
-        new io.swagger.v3.oas.models.responses.ApiResponse();
-    response.setDescription(description);
+  private ApiResponse createErrorResponse(HttpStatus status, String message) {
+    ApiResponse response = new ApiResponse();
+    response.setDescription(message);
 
-    // 에러 응답 스키마 정의
-    io.swagger.v3.oas.models.media.Content content = new io.swagger.v3.oas.models.media.Content();
-    io.swagger.v3.oas.models.media.MediaType mediaType =
-        new io.swagger.v3.oas.models.media.MediaType();
+    Schema<?> errorSchema =
+        new Schema<>()
+            .type("object")
+            .addProperty("status", new Schema<>().type("integer").example(status.value()))
+            .addProperty("message", new Schema<>().type("string").example(message))
+            .addProperty("timestamp", new Schema<>().type("string").format("date-time"));
 
-    io.swagger.v3.oas.models.media.Schema<?> errorSchema =
-        new io.swagger.v3.oas.models.media.Schema<>();
-    errorSchema.setType("object");
-    errorSchema.addProperty(
-        "status",
-        new io.swagger.v3.oas.models.media.Schema<>()
-            .type("integer")
-            .example(Integer.parseInt(status)));
-    errorSchema.addProperty(
-        "message",
-        new io.swagger.v3.oas.models.media.Schema<>().type("string").example(description));
-    errorSchema.addProperty(
-        "timestamp",
-        new io.swagger.v3.oas.models.media.Schema<>().type("string").format("date-time"));
-
-    mediaType.setSchema(errorSchema);
-    content.addMediaType("application/json", mediaType);
+    MediaType mediaType = new MediaType().schema(errorSchema);
+    Content content = new Content().addMediaType("application/json", mediaType);
     response.setContent(content);
 
     return response;

--- a/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
@@ -48,7 +48,7 @@ public class SwaggerConfig {
   public GroupedOpenApi generalApi() {
     return GroupedOpenApi.builder()
         .group("general")
-        .pathsToMatch("/**")
+        .pathsToMatch("/api/**")
         .pathsToExclude("/api/admin/**")
         .addOperationCustomizer(customize())
         .build();

--- a/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/common/swagger/config/SwaggerConfig.java
@@ -71,8 +71,77 @@ public class SwaggerConfig {
       if (methodAnnotation != null) {
         operation.setSecurity(Collections.emptyList());
       }
+
+      // 공통 응답 스키마 적용
+      addCommonResponses(operation);
+
       return operation;
     };
+  }
+
+  private void addCommonResponses(io.swagger.v3.oas.models.Operation operation) {
+    if (operation.getResponses() == null) {
+      operation.setResponses(new io.swagger.v3.oas.models.responses.ApiResponses());
+    }
+
+    // 400 Bad Request - 잘못된 요청
+    if (!operation.getResponses().containsKey("400")) {
+      operation.getResponses().addApiResponse("400", createErrorResponse("잘못된 요청입니다.", "400"));
+    }
+
+    // 401 Unauthorized - 인증 실패 (보안이 필요한 엔드포인트만)
+    if (operation.getSecurity() != null
+        && !operation.getSecurity().isEmpty()
+        && !operation.getResponses().containsKey("401")) {
+      operation.getResponses().addApiResponse("401", createErrorResponse("인증이 필요합니다.", "401"));
+    }
+
+    // 403 Forbidden - 권한 없음 (보안이 필요한 엔드포인트만)
+    if (operation.getSecurity() != null
+        && !operation.getSecurity().isEmpty()
+        && !operation.getResponses().containsKey("403")) {
+      operation.getResponses().addApiResponse("403", createErrorResponse("접근 권한이 없습니다.", "403"));
+    }
+
+    // 500 Internal Server Error - 서버 오류
+    if (!operation.getResponses().containsKey("500")) {
+      operation
+          .getResponses()
+          .addApiResponse("500", createErrorResponse("서버 내부 오류가 발생했습니다.", "500"));
+    }
+  }
+
+  private io.swagger.v3.oas.models.responses.ApiResponse createErrorResponse(
+      String description, String status) {
+    io.swagger.v3.oas.models.responses.ApiResponse response =
+        new io.swagger.v3.oas.models.responses.ApiResponse();
+    response.setDescription(description);
+
+    // 에러 응답 스키마 정의
+    io.swagger.v3.oas.models.media.Content content = new io.swagger.v3.oas.models.media.Content();
+    io.swagger.v3.oas.models.media.MediaType mediaType =
+        new io.swagger.v3.oas.models.media.MediaType();
+
+    io.swagger.v3.oas.models.media.Schema<?> errorSchema =
+        new io.swagger.v3.oas.models.media.Schema<>();
+    errorSchema.setType("object");
+    errorSchema.addProperty(
+        "status",
+        new io.swagger.v3.oas.models.media.Schema<>()
+            .type("integer")
+            .example(Integer.parseInt(status)));
+    errorSchema.addProperty(
+        "message",
+        new io.swagger.v3.oas.models.media.Schema<>().type("string").example(description));
+    errorSchema.addProperty(
+        "timestamp",
+        new io.swagger.v3.oas.models.media.Schema<>().type("string").format("date-time"));
+
+    mediaType.setSchema(errorSchema);
+    content.addMediaType("application/json", mediaType);
+    response.setContent(content);
+
+    return response;
   }
 
   private Info apiInfo() {

--- a/src/main/java/depromeet/lessonfour/server/users/adapters/UserRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/users/adapters/UserRepository.java
@@ -1,13 +1,12 @@
 package depromeet.lessonfour.server.users.adapters;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import depromeet.lessonfour.server.users.domain.entities.User;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
 

--- a/src/main/java/depromeet/lessonfour/server/users/controllers/AuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/users/controllers/AuthController.java
@@ -21,9 +21,13 @@ import depromeet.lessonfour.server.auth.service.dto.AuthTokenDto;
 import depromeet.lessonfour.server.users.schemas.request.RegisterRequestDto;
 import depromeet.lessonfour.server.users.schemas.response.AccessTokenResponseDto;
 import depromeet.lessonfour.server.users.services.SignupUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "인증", description = "로컬 회원가입 및 토큰 갱신 API 문서입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -32,6 +36,9 @@ public class AuthController {
   private final SignupUseCase registerUseCase;
   private final RefreshTokenUseCase refreshTokenUseCase;
 
+  @Operation(
+      summary = "로컬 회원가입",
+      description = "이메일과 비밀번호로 회원가입을 진행합니다. 성공 시 201 Created와 함께 생성된 유저 정보를 반환합니다.")
   @PostMapping(
       path = "/signup",
       consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -42,6 +49,10 @@ public class AuthController {
     return ResponseEntity.created(URI.create("/api/v1/users/" + user.id())).body(user);
   }
 
+  @Operation(
+      summary = "토큰 갱신",
+      description = "만료된 access token을 갱신합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
   @PostMapping("/refresh")
   public ResponseEntity<?> refresh(
       @CookieValue(value = REFRESH_TOKEN_COOKIE_NAME, required = false) String refreshToken) {

--- a/src/main/java/depromeet/lessonfour/server/users/controllers/AuthTestController.java
+++ b/src/main/java/depromeet/lessonfour/server/users/controllers/AuthTestController.java
@@ -5,8 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import depromeet.lessonfour.server.users.services.UserQueryService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 
+@Hidden
 @Profile("dev")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/depromeet/lessonfour/server/users/domain/entities/User.java
+++ b/src/main/java/depromeet/lessonfour/server/users/domain/entities/User.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.users.domain.entities;
 
-import java.util.UUID;
-
 import depromeet.lessonfour.server.common.entities.BaseTimeEntity;
 import depromeet.lessonfour.server.users.domain.values.Provider;
 import jakarta.persistence.Column;
@@ -28,8 +26,8 @@ import lombok.NoArgsConstructor;
 public class User extends BaseTimeEntity {
 
   @Id
-  @GeneratedValue(strategy = GenerationType.UUID)
-  private UUID id;
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
   @NotNull @Column(unique = true, nullable = false)
   private String email;

--- a/src/main/java/depromeet/lessonfour/server/users/schemas/response/AuthResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/users/schemas/response/AuthResponseDto.java
@@ -1,13 +1,11 @@
 package depromeet.lessonfour.server.users.schemas.response;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import depromeet.lessonfour.server.users.domain.values.Provider;
 
 public record AuthResponseDto(
-    UUID id,
+    Long id,
     String email,
     String nickname,
     Provider provider,

--- a/src/main/java/depromeet/lessonfour/server/users/schemas/response/UserResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/users/schemas/response/UserResponseDto.java
@@ -1,14 +1,12 @@
 package depromeet.lessonfour.server.users.schemas.response;
 
-import java.util.UUID;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import depromeet.lessonfour.server.users.domain.entities.User;
 import depromeet.lessonfour.server.users.domain.values.Provider;
 
 public record UserResponseDto(
-    UUID id,
+    Long id,
     String email,
     String nickname,
     Provider provider,

--- a/src/main/java/depromeet/lessonfour/server/users/services/UserUpdateService.java
+++ b/src/main/java/depromeet/lessonfour/server/users/services/UserUpdateService.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.users.services;
 
-import java.util.UUID;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +13,7 @@ public class UserUpdateService {
 
   private final UserRepository userRepository;
 
-  public void updateRefreshToken(UUID userId, String newRefreshToken) {
+  public void updateRefreshToken(Long userId, String newRefreshToken) {
     userRepository
         .findById(userId)
         .ifPresent(

--- a/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
+++ b/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
@@ -1,0 +1,41 @@
+-- 1) 새 auto-increment 컬럼 추가
+alter table activity_record add column id_new bigint generated always as identity;
+alter table food_record     add column id_new bigint generated always as identity;
+alter table foods           add column id_new bigint generated always as identity;
+
+-- 2) food_record FK 드롭
+alter table food_record drop constraint fk_food_record_food;
+alter table food_record drop constraint fk_food_record_activity;
+
+-- 3) food_record FK 컬럼 타입 변환 (uuid → bigint)
+alter table food_record alter column food_id type bigint using null;
+alter table food_record alter column activity_record_id type bigint using null;
+
+-- 4) 기존 PK 드롭
+alter table foods           drop constraint foods_pkey;
+alter table food_record     drop constraint food_record_pkey;
+alter table activity_record drop constraint activity_record_pkey;
+
+-- 5) 새 PK 추가 (테이블명 기준 default style 유지)
+alter table foods           add constraint foods_pkey primary key (id_new);
+alter table food_record     add constraint food_record_pkey primary key (id_new);
+alter table activity_record add constraint activity_record_pkey primary key (id_new);
+
+-- 6) FK 재생성
+alter table food_record
+    add constraint fk_food_record_activity
+        foreign key (activity_record_id) references activity_record (id_new) on delete restrict;
+
+alter table food_record
+    add constraint fk_food_record_food
+        foreign key (food_id) references foods (id_new) on delete restrict;
+
+-- 7) 기존 uuid 컬럼 제거
+alter table activity_record drop column id;
+alter table food_record     drop column id;
+alter table foods           drop column id;
+
+-- 8) 새 컬럼 이름 변경
+alter table foods           rename column id_new to id;
+alter table food_record     rename column id_new to id;
+alter table activity_record rename column id_new to id;

--- a/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
+++ b/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
@@ -17,7 +17,12 @@ alter table toilet_record  drop constraint fk_toilet_record_user;
  alter table toilet_record add column user_id_new bigint;
 
  -- 3-b) 참조 매핑 (기존 UUID → 대상 id_new)
- update food_record fr
+-- (선행) 참조 테이블 id_new 백필 - 매핑 전 필수!
+update foods            set id_new = default where id_new is null;
+update activity_record  set id_new = default where id_new is null;
+update users            set id_new = default where id_new is null;
+
+update food_record fr
          set food_id_new = f.id_new
         from foods f
        where fr.food_id = f.id;
@@ -44,6 +49,12 @@ alter table toilet_record  drop constraint fk_toilet_record_user;
  alter table toilet_record drop column user_id;
  alter table toilet_record rename column user_id_new to user_id;
 
+-- 3-d) NOT NULL 제약 복원 (기존 스키마와 동일하게)
+alter table food_record     alter column food_id             set not null;
+alter table food_record     alter column activity_record_id  set not null;
+alter table activity_record alter column user_id             set not null;
+alter table toilet_record   alter column user_id             set not null;
+
 -- 4) 기존 PK 드롭
 alter table foods           drop constraint foods_pkey;
 alter table food_record     drop constraint food_record_pkey;
@@ -51,11 +62,8 @@ alter table activity_record drop constraint activity_record_pkey;
 alter table users           drop constraint users_pkey;
 
 -- 5) 새 PK 추가 (default naming 유지)
--- (선행) 기존 행에 id_new 백필
-update foods set id_new = default where id_new is null;
+-- (선행) 기존 행에 id_new 백필 (food_record만 필요 - 나머지는 3-b에서 완료)
 update food_record set id_new = default where id_new is null;
-update activity_record set id_new = default where id_new is null;
-update users set id_new = default where id_new is null;
 
 alter table foods           add constraint foods_pkey primary key (id_new);
 alter table food_record     add constraint food_record_pkey primary key (id_new);

--- a/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
+++ b/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
@@ -10,11 +10,39 @@ alter table food_record   drop constraint fk_food_record_activity;
 alter table activity_record drop constraint fk_activity_record_user;
 alter table toilet_record  drop constraint fk_toilet_record_user;
 
--- 3) FK 컬럼 타입 변환: uuid → bigint
-alter table food_record alter column food_id type bigint using null;
-alter table food_record alter column activity_record_id type bigint using null;
-alter table activity_record alter column user_id type bigint using null;
-alter table toilet_record alter column user_id type bigint using null;
+ -- 3-a) FK 매핑용 신규 컬럼 추가
+ alter table food_record add column food_id_new bigint;
+ alter table food_record add column activity_record_id_new bigint;
+ alter table activity_record add column user_id_new bigint;
+ alter table toilet_record add column user_id_new bigint;
+
+ -- 3-b) 참조 매핑 (기존 UUID → 대상 id_new)
+ update food_record fr
+         set food_id_new = f.id_new
+        from foods f
+       where fr.food_id = f.id;
+ update food_record fr
+         set activity_record_id_new = ar.id_new
+        from activity_record ar
+       where fr.activity_record_id = ar.id;
+ update activity_record ar
+         set user_id_new = u.id_new
+        from users u
+       where ar.user_id = u.id;
+ update toilet_record tr
+         set user_id_new = u.id_new
+        from users u
+       where tr.user_id = u.id;
+
+ -- 3-c) 교체
+ alter table food_record drop column food_id;
+ alter table food_record rename column food_id_new to food_id;
+ alter table food_record drop column activity_record_id;
+ alter table food_record rename column activity_record_id_new to activity_record_id;
+ alter table activity_record drop column user_id;
+ alter table activity_record rename column user_id_new to user_id;
+ alter table toilet_record drop column user_id;
+ alter table toilet_record rename column user_id_new to user_id;
 
 -- 4) 기존 PK 드롭
 alter table foods           drop constraint foods_pkey;
@@ -23,6 +51,12 @@ alter table activity_record drop constraint activity_record_pkey;
 alter table users           drop constraint users_pkey;
 
 -- 5) 새 PK 추가 (default naming 유지)
+-- (선행) 기존 행에 id_new 백필
+update foods set id_new = default where id_new is null;
+update food_record set id_new = default where id_new is null;
+update activity_record set id_new = default where id_new is null;
+update users set id_new = default where id_new is null;
+
 alter table foods           add constraint foods_pkey primary key (id_new);
 alter table food_record     add constraint food_record_pkey primary key (id_new);
 alter table activity_record add constraint activity_record_pkey primary key (id_new);

--- a/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
+++ b/src/main/resources/db/migration/V7__activity_records_auto_increment_id.sql
@@ -2,24 +2,31 @@
 alter table activity_record add column id_new bigint generated always as identity;
 alter table food_record     add column id_new bigint generated always as identity;
 alter table foods           add column id_new bigint generated always as identity;
+alter table users           add column id_new bigint generated always as identity;
 
--- 2) food_record FK 드롭
-alter table food_record drop constraint fk_food_record_food;
-alter table food_record drop constraint fk_food_record_activity;
+-- 2) FK 드롭 (food_record, activity_record, toilet_record)
+alter table food_record   drop constraint fk_food_record_food;
+alter table food_record   drop constraint fk_food_record_activity;
+alter table activity_record drop constraint fk_activity_record_user;
+alter table toilet_record  drop constraint fk_toilet_record_user;
 
--- 3) food_record FK 컬럼 타입 변환 (uuid → bigint)
+-- 3) FK 컬럼 타입 변환: uuid → bigint
 alter table food_record alter column food_id type bigint using null;
 alter table food_record alter column activity_record_id type bigint using null;
+alter table activity_record alter column user_id type bigint using null;
+alter table toilet_record alter column user_id type bigint using null;
 
 -- 4) 기존 PK 드롭
 alter table foods           drop constraint foods_pkey;
 alter table food_record     drop constraint food_record_pkey;
 alter table activity_record drop constraint activity_record_pkey;
+alter table users           drop constraint users_pkey;
 
--- 5) 새 PK 추가 (테이블명 기준 default style 유지)
+-- 5) 새 PK 추가 (default naming 유지)
 alter table foods           add constraint foods_pkey primary key (id_new);
 alter table food_record     add constraint food_record_pkey primary key (id_new);
 alter table activity_record add constraint activity_record_pkey primary key (id_new);
+alter table users           add constraint users_pkey primary key (id_new);
 
 -- 6) FK 재생성
 alter table food_record
@@ -30,12 +37,22 @@ alter table food_record
     add constraint fk_food_record_food
         foreign key (food_id) references foods (id_new) on delete restrict;
 
--- 7) 기존 uuid 컬럼 제거
+alter table activity_record
+    add constraint fk_activity_record_user
+        foreign key (user_id) references users (id_new) on delete restrict;
+
+alter table toilet_record
+    add constraint fk_toilet_record_user
+        foreign key (user_id) references users (id_new) on delete restrict;
+
+-- 7) 기존 uuid PK 컬럼 제거
 alter table activity_record drop column id;
 alter table food_record     drop column id;
 alter table foods           drop column id;
+alter table users           drop column id;
 
 -- 8) 새 컬럼 이름 변경
 alter table foods           rename column id_new to id;
 alter table food_record     rename column id_new to id;
 alter table activity_record rename column id_new to id;
+alter table users           rename column id_new to id;

--- a/src/test/java/depromeet/lessonfour/server/auth/persist/jpa/entity/UserTest.java
+++ b/src/test/java/depromeet/lessonfour/server/auth/persist/jpa/entity/UserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Set;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -67,7 +66,7 @@ class UserTest {
     User savedUser = userRepository.save(user);
 
     // then
-    assertThat(savedUser.getId()).isNotNull().isInstanceOf(UUID.class);
+    assertThat(savedUser.getId()).isNotNull().isInstanceOf(Long.class);
     assertThat(savedUser)
         .extracting("email", "nickname", "password")
         .containsExactly(email, nickname, password);

--- a/src/test/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenGeneratorTest.java
+++ b/src/test/java/depromeet/lessonfour/server/auth/security/jwt/JwtTokenGeneratorTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
-import java.util.UUID;
 
 import javax.crypto.SecretKey;
 
@@ -43,7 +42,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateAccessToken_thenReturnValidToken() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -70,7 +69,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateAccessToken_thenExpirationTimeIsCorrect() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -114,7 +113,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateRefreshToken_thenReturnValidToken() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -141,7 +140,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateRefreshToken_thenExpirationTimeIsSevenDays() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -173,7 +172,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateRefreshToken_thenDoesNotContainUserInfoClaims() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -198,7 +197,7 @@ class JwtTokenGeneratorTest {
     void givenValidUser_whenGenerateRefreshToken_thenContainsUniqueJti() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -243,7 +242,7 @@ class JwtTokenGeneratorTest {
     void givenTestConfiguration_whenGenerateTokens_thenExpirationTimeIsCorrect() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -285,7 +284,7 @@ class JwtTokenGeneratorTest {
     void givenGeneratedTokens_whenVerifySignature_thenVerificationSucceeds() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       // when
@@ -309,7 +308,7 @@ class JwtTokenGeneratorTest {
     void givenGeneratedToken_whenVerifyWithWrongKey_thenThrowException() {
       // given
       User user = User.register("test@example.com", "testuser", "password123");
-      ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+      ReflectionTestUtils.setField(user, "id", 1L);
       AccountContext accountContext = AccountContext.of(user);
 
       String accessToken = jwtTokenGenerator.generateAccessToken(accountContext);

--- a/src/test/java/depromeet/lessonfour/server/auth/security/rest/RestAuthenticationSuccessHandlerTest.java
+++ b/src/test/java/depromeet/lessonfour/server/auth/security/rest/RestAuthenticationSuccessHandlerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -71,7 +70,7 @@ class RestAuthenticationSuccessHandlerTest {
         .thenReturn("mock-refresh-token");
     when(objectMapper.writeValueAsString(any()))
         .thenReturn("{\"accessToken\":\"mock-access-token\"}");
-    when(accountContext.getId()).thenReturn(UUID.randomUUID());
+    when(accountContext.getId()).thenReturn(1L);
   }
 
   @Test


### PR DESCRIPTION
## Related Issue 🔗
- closes #47 

## Summary 📝
* 생활 기록 API 문서 추가
  * 생성 API
  * 조회 API
  * 삭제 API
  * 수정 API
* swagger 버전 변경
* 서버 내부 테스트용 API 문서 제외
* swagger 공통 응답 설정

## Changes ✨
* swagger 2.3 -> swagger 2.8
* EchoController, HealthCheckController, Auth Test Controller API 문서에서 제외
* /api/v1/activity-records API 문서 추가

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<img width="1475" height="843" alt="스크린샷 2025-09-14 오전 4 23 21" src="https://github.com/user-attachments/assets/b3ea2507-7738-4b70-9392-e30f94208daf" />

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 생활 기록 API 추가: 생성·수정·삭제·날짜별 조회 엔드포인트 및 요청 검증.

- Refactor
  - 주요 엔티티와 응답 ID를 UUID에서 숫자형(Long, IDENTITY)으로 전환.

- Documentation
  - 공통 오류 응답(400/401/403/500) 자동 추가 및 /api/** 경로만 문서화.
  - 헬스체크·에코·개발용 인증 컨트롤러는 API 문서에서 숨김.
  - 인증 엔드포인트에 상세 OpenAPI 주석 추가.

- Chores
  - OpenAPI 라이브러리 버전 업데이트.
  - DB 마이그레이션으로 자동 증가 bigint ID 적용.
  - 활동 기록 API를 공개 엔드포인트로 허용.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->