### PR TITLE
[#54] fix : 존재하지 않는 경로로 요청 시 404 반환

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/common/exception/code/ErrorCode.java
+++ b/src/main/java/depromeet/lessonfour/server/common/exception/code/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode implements BaseErrorCode {
   */
   DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다"),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다"),
+  PATH_NOT_FOUND(HttpStatus.NOT_FOUND, "잘못된 요청 경로입니다."),
 
   /*
   409 CONFLICT

--- a/src/main/java/depromeet/lessonfour/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/depromeet/lessonfour/server/common/exception/handler/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.common.exception.base.BaseErrorCode;
@@ -100,6 +101,12 @@ public class GlobalExceptionHandler {
             ? "요청 Content-Type: " + e.getContentType()
             : "요청 Content-Type 누락";
     return buildErrorResponse(ErrorCode.UNSUPPORTED_MEDIA_TYPE, detail);
+  }
+
+  @ExceptionHandler(NoHandlerFoundException.class)
+  public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+    String detail = String.format("잘못된 요청 경로: %s %s", e.getHttpMethod(), e.getRequestURL());
+    return buildErrorResponse(ErrorCode.PATH_NOT_FOUND, detail);
   }
 
   private ResponseEntity<ErrorResponse> buildErrorResponse(BaseErrorCode errorCode, Object detail) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,11 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
+  mvc:
+    throw-exception-if-no-handler-found: true
+  web:
+    resources:
+      add-mappings: false
 
 jwt:
   secret: mySecretKeyForJWTWhichShouldBeAtLeast256BitsLongToEnsureSecurityAndCompliance

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,6 @@ spring:
     enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
-  mvc:
-    throw-exception-if-no-handler-found: true
   web:
     resources:
       add-mappings: false

--- a/src/test/java/depromeet/lessonfour/server/common/exception/handler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/depromeet/lessonfour/server/common/exception/handler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,34 @@
+package depromeet.lessonfour.server.common.exception.handler;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import io.restassured.RestAssured;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GlobalExceptionHandlerTest {
+
+  @LocalServerPort private int port;
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 경로 호출 시 404 Not Found 반환")
+  void whenNonExistingPathCalled_thenReturnNotFoundException() {
+    given()
+        .when()
+        .get("/non-existent-path") // 존재하지 않는 엔드포인트
+        .then()
+        .statusCode(404); // 404 기대
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
- closes #54 

## Summary 📝
* 존재하지 않는 경로로 요청시 404 에러 코드를 반환하도록 수정

## Changes ✨
* 존재하지 않는 경로 요청 시 500 에러를 반환 -> 404에러 반환
* 테스트 코드 작성

## Why we need 💡
안정적인 Http Status를 내려주기 위해 필요

## Test 🧪
GlobalExceptionHandlerTest 추가

## Trouble Shooting 🐛
```
spring:
  web:
    resources:
      add-mappings: false
```
설정을 추가해야 mvc template을 찾지 않고 NoHandlerFoundException을 던지게 됩니다.

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 존재하지 않는 경로 요청 시 일관된 404 Not Found 응답을 반환하도록 개선했습니다.
  - 한국어 안내 메시지(“잘못된 요청 경로입니다.”)로 사용자가 문제를 쉽게 파악할 수 있습니다.
  - 예외 상황에서도 에러 응답 포맷이 통일되어 사용자 경험이 향상되었습니다.

- 테스트
  - 미존재 경로에 대한 404 응답을 검증하는 통합 테스트를 추가하여 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->