### PR TITLE
Bugfix/auth tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Python ###
+poetry.lock
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ ssh:
 	ssh root@${APP__SERVER__URL}
 
 poetry:
-	@pip install poetry
+	@command -v poetry >/dev/null 2>&1 || pip install poetry
 
 auth-test: poetry
 	@(cd src/test/python/auth-test && poetry install && SERVER_URL=${APP__SERVER__URL} poetry run python -m auth_test.main)

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,21 @@ curl:
 	curl -sS http://localhost:$(PORT)/api/v1/echo || true; echo
 
 postgres:
-	@echo "Creating postgres container..."; \
-	docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=dpm -e POSTGRES_DB=dpm postgres; \
-	echo "Done."
+	@echo "Creating postgres container..."
+	@docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=dpm -e POSTGRES_DB=dpm postgres
+	@echo "Done."
 
 postgres-stop:
-	@echo "Stopping postgres container..."; \
-	docker stop postgres; \
-	echo "Done."
+	@echo "Stopping postgres container..."
+	@docker stop postgres
+	@docker rm postgres
+	@echo "Done."
+
+frontend-install:
+	@pip install "uvicorn[standard]" fastapi
+
+frontend:
+	@SERVER_URL=${APP__SERVER__URL} python src/test/python/frontend.py
+
+frontend-dev:
+	@SERVER_URL=http://localhost:${PORT} python src/test/python/frontend.py

--- a/Makefile
+++ b/Makefile
@@ -149,5 +149,5 @@ ssh:
 poetry:
 	@pip install poetry
 
-auth-test:
+auth-test: poetry
 	@(cd src/test/python/auth-test && poetry install && SERVER_URL=${APP__SERVER__URL} poetry run python -m auth_test.main)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PID_FILE := .server.pid
 LOG_DIR := logs
 LOG_FILE := $(LOG_DIR)/server.log
 
-.PHONY: help build build-no-test jar run start stop restart status logs test clean curl format format-check clear-h2
+.PHONY: help build build-no-test jar run start stop restart status logs test clean curl format format-check clear-h2 ssh
 
 help:
 	@echo "Available targets:"
@@ -151,3 +151,6 @@ frontend:
 
 frontend-dev:
 	@SERVER_URL=http://localhost:${PORT} python src/test/python/frontend.py
+
+ssh:
+	ssh root@${APP__SERVER__URL}

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PID_FILE := .server.pid
 LOG_DIR := logs
 LOG_FILE := $(LOG_DIR)/server.log
 
-.PHONY: help build build-no-test jar run start stop restart status logs test clean curl format format-check clear-h2 ssh
+.PHONY: help build build-no-test jar run start stop restart status logs test clean curl format format-check clear-h2 ssh poetry auth-test
 
 help:
 	@echo "Available targets:"
@@ -143,14 +143,11 @@ postgres-stop:
 	@docker rm postgres
 	@echo "Done."
 
-frontend-install:
-	@pip install "uvicorn[standard]" fastapi
-
-frontend:
-	@SERVER_URL=${APP__SERVER__URL} python src/test/python/frontend.py
-
-frontend-dev:
-	@SERVER_URL=http://localhost:${PORT} python src/test/python/frontend.py
-
 ssh:
 	ssh root@${APP__SERVER__URL}
+
+poetry:
+	@pip install poetry
+
+auth-test:
+	@(cd src/test/python/auth-test && poetry install && SERVER_URL=${APP__SERVER__URL} poetry run python -m auth_test.main)

--- a/manifests/nginx.conf
+++ b/manifests/nginx.conf
@@ -1,0 +1,29 @@
+# configuration file /etc/nginx/sites-enabled/default:
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name 211.188.58.167;
+
+    ssl_certificate     /root/server.crt;
+    ssl_certificate_key /root/server.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
@@ -66,7 +66,6 @@ public class AuthController {
 
     // Refresh Token Rotation: 새로운 refresh token을 쿠키로 업데이트
     ResponseCookie refreshTokenCookie = RefreshTokenCookieGenerator.generate(result.refreshToken());
-    System.out.println("refresh_token: " + result.refreshToken());
     return ResponseEntity.ok()
         .header("Set-Cookie", refreshTokenCookie.toString())
         .cacheControl(CacheControl.noStore().mustRevalidate())

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+import depromeet.lessonfour.server.auth.api.util.RefreshTokenCookieGenerator;
 import depromeet.lessonfour.server.auth.app.dto.response.AuthTokenDto;
 import depromeet.lessonfour.server.auth.app.service.RefreshTokenUseCase;
 import depromeet.lessonfour.server.user.app.dto.request.RegisterRequestDto;
@@ -64,14 +65,7 @@ public class AuthController {
     AuthTokenDto result = refreshTokenUseCase.refresh(refreshToken);
 
     // Refresh Token Rotation: 새로운 refresh token을 쿠키로 업데이트
-    ResponseCookie refreshTokenCookie =
-        ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, result.refreshToken())
-            .httpOnly(true)
-            .sameSite("Strict")
-            .maxAge(7 * 24 * 60 * 60) // 7일
-            .path("/")
-            .build();
-    // .secure(true) // HTTPS에서만 전송
+    ResponseCookie refreshTokenCookie = RefreshTokenCookieGenerator.generate(result.refreshToken());
     System.out.println("refresh_token: " + result.refreshToken());
     return ResponseEntity.ok()
         .header("Set-Cookie", refreshTokenCookie.toString())

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -45,19 +45,22 @@ public class KakaoAuthController {
 
   @Operation(summary = "카카오 로그인", description = "카카오를 통해 로그인을 진행합니다.")
   @PostMapping("/login")
-  public ResponseEntity<Void> kakaoLogin() {
-    String authUrl = kakaoAuthService.getRequestUrl();
+  public ResponseEntity<Void> kakaoLogin(
+      @RequestParam(required = false) String redirectUri) {
+    String authUrl = kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl);
     return ResponseEntity.status(302).header("Location", authUrl).build();
   }
 
   @Hidden
   @GetMapping("/callback")
-  public ResponseEntity<Void> kakaoCallback(
-      @RequestParam(required = false) String code, @RequestParam(required = false) String error) {
-
+  public ResponseEntity<Void> kakaoLegacyCallback(
+      @RequestParam(required = false) String code,
+      @RequestParam(required = false) String error,
+      @RequestParam(required = false) String state) {
+    String clientRedirectUri = state != null ? state : frontendUrl;
     if (error != null) {
       String errorUrl =
-          UriComponentsBuilder.fromUriString(frontendUrl)
+          UriComponentsBuilder.fromUriString(clientRedirectUri)
               .queryParam("error", "OAuth error: " + error)
               .encode(StandardCharsets.UTF_8)
               .build()
@@ -72,7 +75,7 @@ public class KakaoAuthController {
         ResponseCookie refreshTokenCookie =
             RefreshTokenCookieGenerator.generate(authResult.refreshToken());
         String successUrl =
-            UriComponentsBuilder.fromUriString(frontendUrl)
+            UriComponentsBuilder.fromUriString(clientRedirectUri)
                 .queryParam("id", authResult.id())
                 .queryParam("nickname", authResult.nickname())
                 .queryParam("profileImage", authResult.profileImage())
@@ -90,7 +93,7 @@ public class KakaoAuthController {
 
       } catch (Exception e) {
         String errorUrl =
-            UriComponentsBuilder.fromUriString(frontendUrl)
+            UriComponentsBuilder.fromUriString(clientRedirectUri)
                 .queryParam("error", "Authentication failed: " + e.getMessage())
                 .encode(StandardCharsets.UTF_8)
                 .build()
@@ -100,7 +103,7 @@ public class KakaoAuthController {
     }
 
     String errorUrl =
-        UriComponentsBuilder.fromUriString(frontendUrl)
+        UriComponentsBuilder.fromUriString(clientRedirectUri)
             .queryParam("error", "No code or error received")
             .encode(StandardCharsets.UTF_8)
             .build()

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -71,7 +71,6 @@ public class KakaoAuthController {
     if (code != null) {
       try {
         AuthResponseDto authResult = kakaoAuthService.login(code);
-        System.out.println("refreshToken: " + authResult.refreshToken());
         ResponseCookie refreshTokenCookie =
             RefreshTokenCookieGenerator.generate(authResult.refreshToken());
         String successUrl =

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -13,9 +13,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import depromeet.lessonfour.server.auth.api.util.RefreshTokenCookieGenerator;
 import depromeet.lessonfour.server.auth.app.service.KakaoAuthService;
 import depromeet.lessonfour.server.user.app.dto.response.AuthResponseDto;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "카카오 인증", description = "카카오 인증에 대한 API 문서입니다.")
 @RestController
 @RequestMapping("/api/v1/auth/kakao")
 public class KakaoAuthController {
@@ -38,12 +43,14 @@ public class KakaoAuthController {
     this.kakaoAuthService = kakaoAuthService;
   }
 
+  @Operation(summary = "카카오 로그인", description = "카카오를 통해 로그인을 진행합니다.")
   @PostMapping("/login")
   public ResponseEntity<Void> kakaoLogin() {
     String authUrl = kakaoAuthService.getRequestUrl();
     return ResponseEntity.status(302).header("Location", authUrl).build();
   }
 
+  @Hidden
   @GetMapping("/callback")
   public ResponseEntity<Void> kakaoCallback(
       @RequestParam(required = false) String code, @RequestParam(required = false) String error) {
@@ -63,14 +70,7 @@ public class KakaoAuthController {
         AuthResponseDto authResult = kakaoAuthService.login(code);
         System.out.println("refreshToken: " + authResult.refreshToken());
         ResponseCookie refreshTokenCookie =
-            ResponseCookie.from("refreshToken", authResult.refreshToken())
-                .httpOnly(true)
-                .sameSite("None") // Strict
-                .maxAge(7 * 24 * 60 * 60) // 7일
-                .path("/")
-                .build();
-        // .secure(true) // HTTPS에서만 전송
-
+            RefreshTokenCookieGenerator.generate(authResult.refreshToken());
         String successUrl =
             UriComponentsBuilder.fromUriString(frontendUrl)
                 .queryParam("id", authResult.id())
@@ -81,11 +81,6 @@ public class KakaoAuthController {
                 .encode(StandardCharsets.UTF_8)
                 .build()
                 .toUriString();
-
-        /*
-        System.out.println(
-            "User authenticated: " + user.getUsername() + " (" + user.getEmail() + ")");
-        */
 
         return ResponseEntity.status(302)
             .header("Location", successUrl)

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -45,9 +45,9 @@ public class KakaoAuthController {
 
   @Operation(summary = "카카오 로그인", description = "카카오를 통해 로그인을 진행합니다.")
   @PostMapping("/login")
-  public ResponseEntity<Void> kakaoLogin(
-      @RequestParam(required = false) String redirectUri) {
-    String authUrl = kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl);
+  public ResponseEntity<Void> kakaoLogin(@RequestParam(required = false) String redirectUri) {
+    String authUrl =
+        kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl);
     return ResponseEntity.status(302).header("Location", authUrl).build();
   }
 

--- a/src/main/java/depromeet/lessonfour/server/auth/api/util/RefreshTokenCookieGenerator.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/util/RefreshTokenCookieGenerator.java
@@ -8,10 +8,10 @@ public class RefreshTokenCookieGenerator {
   public static ResponseCookie generate(String refreshToken) {
     return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
         .httpOnly(true)
-        .sameSite("Lax") // Strict
-        .maxAge(7 * 24 * 60 * 60) // 7일
+        .sameSite("None")
+        .maxAge(7 * 24 * 60 * 60)
         .path("/")
-        .secure(false) // HTTP에서도 전송
+        .secure(true)
         .build();
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/auth/api/util/RefreshTokenCookieGenerator.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/util/RefreshTokenCookieGenerator.java
@@ -1,0 +1,17 @@
+package depromeet.lessonfour.server.auth.api.util;
+
+import static depromeet.lessonfour.server.auth.infra.security.jwt.JwtConstants.REFRESH_TOKEN_COOKIE_NAME;
+
+import org.springframework.http.ResponseCookie;
+
+public class RefreshTokenCookieGenerator {
+  public static ResponseCookie generate(String refreshToken) {
+    return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+        .httpOnly(true)
+        .sameSite("Lax") // Strict
+        .maxAge(7 * 24 * 60 * 60) // 7일
+        .path("/")
+        .secure(false) // HTTP에서도 전송
+        .build();
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
@@ -81,12 +81,13 @@ public class KakaoAuthService {
     throw new ServerException(AuthErrorCode.LOGIN_CODE_REQUIRED);
   }
 
-  public String getRequestUrl() {
+  public String getRequestUrl(String clientRedirectUri) {
     MultiValueMap<String, String> authParams =
         new LinkedMultiValueMap<>() {
           {
             add("client_id", clientId);
-            add("redirect_uri", redirectUri);
+            add("redirect_uri", redirectUri); // serverRedirectUri
+            add("state", clientRedirectUri);
             add("response_type", "code");
             add("scope", "openid profile_nickname profile_image account_email");
           }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,7 @@ logging:
       file-name-pattern: logs/server-%d{yyyy-MM-dd}.%i.log.gz
 
 server:
+  forward-headers-strategy: framework
   tomcat:
     basedir: .
     accesslog:

--- a/src/test/python/auth-test/README.md
+++ b/src/test/python/auth-test/README.md
@@ -1,0 +1,1 @@
+# Auth Test

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -14,8 +14,8 @@ import json
 
 
 app = FastAPI(title="Kakao OAuth Login Service", version="1.0.0")
-SERVER_URL = os.environ.get("SERVER_URL", "http://211.188.58.167")
-# SERVER_URL = "http://localhost:8080"
+SERVICE_PORT = int(os.environ.get("SERVICE_PORT", 3000))
+SERVER_URL = os.environ.get("SERVER_URL", f"http://localhost:8080")
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
@@ -193,8 +193,6 @@ async def home(request: Request):
     """
     return HTMLResponse(content=html_content)
 
-
-SERVICE_PORT = int(os.environ.get("SERVICE_PORT", 3000))
 
 if __name__ == "__main__":
     print("🚀 카카오 OAuth 로그인 서비스 시작 중...")

--- a/src/test/python/auth-test/pyproject.toml
+++ b/src/test/python/auth-test/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "auth-test"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "ihnokim",email = "ihnokim58@gmail.com"}
+]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "uvicorn[standard] (>=0.36.0,<0.37.0)",
+    "fastapi (>=0.117.1,<0.118.0)",
+    "pyjwt (>=2.10.1,<3.0.0)",
+    "python-multipart (>=0.0.20,<0.0.21)"
+]
+
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/src/test/python/frontend.py
+++ b/src/test/python/frontend.py
@@ -1,0 +1,206 @@
+from fastapi import FastAPI, HTTPException, Request, Depends
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.security import HTTPBearer
+import httpx
+import uvicorn
+from typing import Optional
+import os
+from datetime import datetime, timedelta
+import jwt
+from jwt import PyJWKClient
+from pydantic import BaseModel
+import uuid
+import json
+
+
+app = FastAPI(title="Kakao OAuth Login Service", version="1.0.0")
+SERVER_URL = os.environ.get("SERVER_URL", "http://211.188.58.167")
+# SERVER_URL = "http://localhost:8080"
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    """홈페이지 - 카카오 로그인 버튼 및 로그인 정보 표시"""
+    
+    # URL 파라미터에서 사용자 정보 추출
+    user_id = request.query_params.get("id")
+    nickname = request.query_params.get("nickname")
+    profile_image = request.query_params.get("profileImage")
+    is_new = request.query_params.get("isNew")
+    provider_type = request.query_params.get("providerType")
+    
+    # 사용자 정보가 있는지 확인
+    has_user_info = any([user_id, nickname, profile_image])
+    
+    # 사용자 정보 섹션 HTML 생성
+    user_info_section = ""
+    if has_user_info:
+        user_info_section = f"""
+        <div class="user-info">
+            <h2>로그인된 사용자</h2>
+            <div class="user-details">
+                {f'<p><strong>ID:</strong> {user_id}</p>' if user_id else ''}
+                {f'<p><strong>닉네임:</strong> {nickname}</p>' if nickname else ''}
+                {f'<p><strong>프로필 이미지:</strong> <img src="{profile_image}" alt="프로필" style="width: 50px; height: 50px; border-radius: 50%;"></p>' if profile_image else ''}
+                {f'<p><strong>신규 사용자:</strong> {is_new}</p>' if is_new else ''}
+                {f'<p><strong>제공자:</strong> {provider_type}</p>' if provider_type else ''}
+            </div>
+        </div>
+        """
+    
+    html_content = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>카카오 로그인 테스트</title>
+        <meta charset="utf-8">
+        <style>
+            body {{ font-family: Arial, sans-serif; text-align: center; margin-top: 50px; }}
+            .login-btn {{ 
+                background-color: #FEE500; 
+                color: #000; 
+                padding: 15px 30px; 
+                border: none; 
+                border-radius: 8px; 
+                font-size: 16px; 
+                cursor: pointer; 
+                text-decoration: none;
+                display: inline-block;
+                margin: 10px;
+            }}
+            .login-btn:hover {{ background-color: #FFD700; }}
+            .token-btn {{
+                background-color: #007bff; 
+                color: #fff; 
+                padding: 15px 30px; 
+                border: none; 
+                border-radius: 8px; 
+                font-size: 16px; 
+                cursor: pointer; 
+                text-decoration: none;
+                display: inline-block;
+                margin: 10px;
+            }}
+            .token-btn:hover {{ background-color: #0056b3; }}
+            .token-section {{
+                margin-top: 20px;
+                padding: 20px;
+                background-color: #f8f9fa;
+                border-radius: 8px;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+            }}
+            .token-input-group {{
+                display: flex;
+                gap: 10px;
+                align-items: center;
+                justify-content: center;
+                flex-wrap: wrap;
+            }}
+            .token-input {{
+                flex: 1;
+                min-width: 300px;
+                padding: 12px 15px;
+                border: 2px solid #ddd;
+                border-radius: 8px;
+                font-size: 14px;
+                font-family: monospace;
+            }}
+            .token-input:focus {{
+                outline: none;
+                border-color: #007bff;
+                box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+            }}
+            .user-info {{
+                margin-top: 30px;
+                padding: 20px;
+                background-color: #f5f5f5;
+                border-radius: 8px;
+                max-width: 500px;
+                margin-left: auto;
+                margin-right: auto;
+                text-align: left;
+            }}
+            .user-details p {{
+                margin: 10px 0;
+            }}
+            .token-info {{
+                margin-top: 20px;
+                padding: 15px;
+                background-color: #e8f4fd;
+                border-radius: 8px;
+                border-left: 4px solid #007bff;
+            }}
+            .token-display {{
+                word-break: break-all;
+                font-family: monospace;
+                background-color: #f8f9fa;
+                padding: 10px;
+                border-radius: 4px;
+                margin-top: 10px;
+            }}
+        </style>
+    </head>
+    <body>
+        <h1>카카오 OAuth 로그인 테스트</h1>
+        <p>아래 버튼을 클릭하여 카카오로 로그인하세요</p>
+        <form action="{SERVER_URL}/api/v1/auth/kakao/login" method="post" style="display:inline;">
+            <button type="submit" class="login-btn">카카오로 로그인</button>
+        </form>
+        
+        <div class="token-section">
+            <div class="token-input-group">
+                <button onclick="getToken()" class="token-btn">Get token</button>
+            </div>
+            <p style="margin-top: 10px; color: #666; font-size: 14px;">
+                Refresh token은 쿠키에서 자동으로 가져옵니다.
+            </p>
+        </div>
+        {user_info_section}
+        
+        <div id="tokenInfo" class="token-info" style="display: none;">
+            <h3>Access Token</h3>
+            <div id="tokenDisplay" class="token-display"></div>
+        </div>
+        
+        <script>
+            async function getToken() {{
+                try {{
+                    const response = await fetch('{SERVER_URL}/api/v1/auth/refresh', {{
+                        method: 'POST',
+                        headers: {{
+                            'Content-Type': 'application/json',
+                        }},
+                        credentials: 'include'  // 쿠키를 포함하여 요청
+                    }});
+                    
+                    if (response.ok) {{
+                        const data = await response.json();
+                        document.getElementById('tokenDisplay').textContent = data.accessToken || 'No token received';
+                        document.getElementById('tokenInfo').style.display = 'block';
+                    }} else {{
+                        const errorData = await response.json();
+                        alert('토큰 가져오기 실패: ' + (errorData.message || 'Unknown error'));
+                    }}
+                }} catch (error) {{
+                    alert('토큰 가져오기 중 오류 발생: ' + error.message);
+                }}
+            }}
+        </script>
+    </body>
+    </html>
+    """
+    return HTMLResponse(content=html_content)
+
+
+SERVICE_PORT = 3000
+
+if __name__ == "__main__":
+    print("🚀 카카오 OAuth 로그인 서비스 시작 중...")
+    print(f"SERVER_URL: {SERVER_URL}")
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=SERVICE_PORT,
+        # reload=True
+    )

--- a/src/test/python/frontend.py
+++ b/src/test/python/frontend.py
@@ -20,7 +20,8 @@ SERVER_URL = os.environ.get("SERVER_URL", "http://211.188.58.167")
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request):
     """홈페이지 - 카카오 로그인 버튼 및 로그인 정보 표시"""
-    
+    print("Set-Cookie headers:", request.headers.get("cookie"))
+
     # URL 파라미터에서 사용자 정보 추출
     user_id = request.query_params.get("id")
     nickname = request.query_params.get("nickname")

--- a/src/test/python/frontend.py
+++ b/src/test/python/frontend.py
@@ -145,7 +145,7 @@ async def home(request: Request):
     <body>
         <h1>카카오 OAuth 로그인 테스트</h1>
         <p>아래 버튼을 클릭하여 카카오로 로그인하세요</p>
-        <form action="{SERVER_URL}/api/v1/auth/kakao/login" method="post" style="display:inline;">
+        <form action="{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=http://localhost:{SERVICE_PORT}" method="post" style="display:inline;">
             <button type="submit" class="login-btn">카카오로 로그인</button>
         </form>
         
@@ -194,7 +194,7 @@ async def home(request: Request):
     return HTMLResponse(content=html_content)
 
 
-SERVICE_PORT = 3000
+SERVICE_PORT = int(os.environ.get("SERVICE_PORT", 3000))
 
 if __name__ == "__main__":
     print("🚀 카카오 OAuth 로그인 서비스 시작 중...")


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #13 

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->

1. NCP 서버의 nginx 설정에 https를 open합니다. (SSL termination) -> Redirection은 설정하지 않았습니다. (http도 리스펙하기)
2. Refresh token을 set-cookie 헤더에 넣을 때 cross-site를 허용하는 대신 secure 옵션을 사용하도록 변경합니다.
3. 프리런칭데이 준비를 위해 기존 kakao login에서 localhost:3000으로 고정되어 있던 redirectUri를 동적으로 변경할 수 있도록 기능이 추가됩니다.
4. OAuth 인증을 위한 빠른 테스트를 위해 python app을 패키징하고, 이를 실행하기 위한 Makefile 타겟들이 추가됩니다.

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

As mentioned above

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

1. 로컬 개발 환경과 원활한 Cookie 교환을 위해 필요합니다.
2. 기존에 SameSite = "Lax" 조건이었는데, 이 경우 GET에서만 cross-site를 허용하기 때문에 POST refresh API를 사용할 수 없게 됩니다.
3. 프리런칭데이에서 프론트엔드의 배포 환경에 따라 localhost:3000이 아닌 호스트에서 요청을 할 수도 있기 때문입니다.
4. OAuth의 경우 E2E 테스트로 점검하기 어렵다는 특성 때문에 직접 python app을 통해 테스트 진행이 필요합니다.

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

- 기존 Swagger에서 발생하던 CORS 오류는 mixed-content 오류 때문으로 파악됩니다. 따라서, http로 열었을 때는 "servers" 항목에서 http를, https로 열었을 때는 https를 선택하여 API 호출을 하면 정상적으로 동작합니다.

<img width="627" height="319" alt="image" src="https://github.com/user-attachments/assets/371085de-2446-4292-bd56-4a5c4191a2ab" />

- Python test app을 통해 로컬 http 환경에서 NCP의 https 기반 서버와의 OAuth 연동이 성공적으로 완료되는 것을 확인했습니다. (Refresh token cookie 기반)

<img width="1203" height="875" alt="image" src="https://github.com/user-attachments/assets/e6cce592-640b-442f-bbfe-de9b3c678b19" />

- Test app을 통해, frontend의 URL이 동적으로 변경되어도 정상적으로 redirection을 통한 OAuth가 동작하는 것을 확인했습니다.
(e.g. 포트를 3000이 아니라 다른 포트를 써버리기!)

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

인증 도메인에 대한 개념이 궁금하시면 커피 한 잔과 함께 설명드리겠습니다 ☕️

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 카카오 로그인에 클라이언트 리디렉션 URI(state) 지원 및 성공/오류 리다이렉트 개선
  - 리프레시 토큰 쿠키 생성 유틸 통합으로 쿠키 설정 일관성 강화
  - API 문서(Swagger) 주석 추가로 카카오 인증 엔드포인트 문서 개선
- **테스트**
  - 카카오 OAuth 검증용 경량 FastAPI 테스트 서비스 및 관련 의존성(pyproject) 추가
- **문서**
  - 테스트 서비스 README 추가
- **작업**
  - nginx 리버스 프록시(HTTP/HTTPS) 및 헤더 포워딩 설정 추가
  - 서버 헤더 포워딩 전략 설정 추가
  - Makefile에 ssh/poetry/auth-test 타깃 추가 및 Postgres 정리 동작 강화
  - .gitignore에 Python 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->