### PR TITLE
Feature/배변기록 CRUD API 구현

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/api/controller/ToiletRecordController.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/api/controller/ToiletRecordController.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.toiletrecord.api.controller;
 
-import java.time.LocalDateTime;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,6 +16,10 @@ import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import depromeet.lessonfour.server.toiletrecord.app.dto.request.ToiletRecordCreateRequestDto;
 import depromeet.lessonfour.server.toiletrecord.app.dto.request.ToiletRecordUpdateRequestDto;
 import depromeet.lessonfour.server.toiletrecord.app.dto.response.ToiletRecordResponseDto;
+import depromeet.lessonfour.server.toiletrecord.app.service.CreateToiletRecordUseCase;
+import depromeet.lessonfour.server.toiletrecord.app.service.DeleteToiletRecordUseCase;
+import depromeet.lessonfour.server.toiletrecord.app.service.QueryToiletRecordUseCase;
+import depromeet.lessonfour.server.toiletrecord.app.service.UpdateToiletRecordUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,6 +32,11 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/poo-records")
 public class ToiletRecordController {
 
+  private final CreateToiletRecordUseCase createUseCase;
+  private final UpdateToiletRecordUseCase updateUseCase;
+  private final DeleteToiletRecordUseCase deleteUseCase;
+  private final QueryToiletRecordUseCase queryUseCase;
+
   @Operation(summary = "배변기록 등록")
   @ApiResponses({
     @ApiResponse(responseCode = "201", description = "success"),
@@ -39,19 +46,8 @@ public class ToiletRecordController {
   public ResponseEntity<SuccessResponse<ToiletRecordResponseDto>> createToiletRecord(
       @Valid @RequestBody ToiletRecordCreateRequestDto request,
       @AuthenticationPrincipal(expression = "id") Long userId) {
-    // 임시 더미 응답
-    ToiletRecordResponseDto response =
-        new ToiletRecordResponseDto(
-            1L, // 생성된 레코드 id (더미)
-            userId, // 작성자 id
-            request.occurredAt(),
-            request.isSuccessful(),
-            request.color(),
-            request.shape(),
-            request.pain(),
-            request.duration(),
-            request.note());
-    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_CREATE, response));
+    return ResponseEntity.ok(
+        SuccessResponse.of(SuccessCode.SUCCESS_CREATE, createUseCase.create(userId, request)));
   }
 
   @Operation(summary = "배변기록 상세조회")
@@ -63,19 +59,9 @@ public class ToiletRecordController {
   @GetMapping("/{toiletRecordId}/detail")
   public ResponseEntity<SuccessResponse<ToiletRecordResponseDto>> getToiletRecordDetail(
       @PathVariable Long toiletRecordId, @AuthenticationPrincipal(expression = "id") Long userId) {
-    // 임시 더미 응답
-    ToiletRecordResponseDto response =
-        new ToiletRecordResponseDto(
-            toiletRecordId,
-            userId,
-            LocalDateTime.now().minusMinutes(10),
-            true,
-            null,
-            null,
-            0,
-            5,
-            null);
-    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, response));
+    return ResponseEntity.ok(
+        SuccessResponse.of(
+            SuccessCode.SUCCESS_FETCH, queryUseCase.getDetail(userId, toiletRecordId)));
   }
 
   @Operation(summary = "배변기록 수정")
@@ -89,19 +75,9 @@ public class ToiletRecordController {
       @Valid @RequestBody ToiletRecordUpdateRequestDto request,
       @PathVariable Long toiletRecordId,
       @AuthenticationPrincipal(expression = "id") Long userId) {
-    // 임시 더미 응답
-    ToiletRecordResponseDto response =
-        new ToiletRecordResponseDto(
-            1L, // 생성된 레코드 id (더미)
-            userId, // 작성자 id
-            request.occurredAt(),
-            request.isSuccessful(),
-            request.color(),
-            request.shape(),
-            request.pain(),
-            request.duration(),
-            request.note());
-    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_UPDATE, response));
+    return ResponseEntity.ok(
+        SuccessResponse.of(
+            SuccessCode.SUCCESS_UPDATE, updateUseCase.update(userId, toiletRecordId, request)));
   }
 
   @Operation(summary = "배변기록 삭제")
@@ -113,6 +89,7 @@ public class ToiletRecordController {
   @DeleteMapping("/{toiletRecordId}")
   public ResponseEntity<SuccessResponse<Void>> deleteToiletRecord(
       @PathVariable Long toiletRecordId, @AuthenticationPrincipal(expression = "id") Long userId) {
+    deleteUseCase.delete(userId, toiletRecordId);
     return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_DELETE));
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/app/repository/ToiletRecordRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/app/repository/ToiletRecordRepository.java
@@ -1,0 +1,14 @@
+package depromeet.lessonfour.server.toiletrecord.app.repository;
+
+import java.util.Optional;
+
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+
+public interface ToiletRecordRepository {
+
+  void save(ToiletRecord record);
+
+  Optional<ToiletRecord> findByUser_IdAndIdAndIsDeletedFalse(Long userId, Long recordId);
+
+  Optional<ToiletRecord> findByIdAndIsDeletedFalse(Long recordId);
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/CreateToiletRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/CreateToiletRecordUseCase.java
@@ -1,0 +1,39 @@
+package depromeet.lessonfour.server.toiletrecord.app.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.toiletrecord.app.dto.request.ToiletRecordCreateRequestDto;
+import depromeet.lessonfour.server.toiletrecord.app.dto.response.ToiletRecordResponseDto;
+import depromeet.lessonfour.server.toiletrecord.app.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import depromeet.lessonfour.server.user.app.service.UserQueryService;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class CreateToiletRecordUseCase {
+
+  private final UserQueryService userQueryService;
+  private final ToiletRecordRepository toiletRecordRepository;
+
+  public ToiletRecordResponseDto create(Long userId, ToiletRecordCreateRequestDto dto) {
+    User user = userQueryService.findById(userId);
+
+    ToiletRecord record =
+        ToiletRecord.register(
+            user,
+            dto.isSuccessful(),
+            dto.color(),
+            dto.shape(),
+            dto.pain(),
+            dto.duration(),
+            dto.note(),
+            dto.occurredAt());
+
+    toiletRecordRepository.save(record);
+    return ToiletRecordResponseDto.of(record);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/DeleteToiletRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/DeleteToiletRecordUseCase.java
@@ -1,0 +1,26 @@
+package depromeet.lessonfour.server.toiletrecord.app.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.toiletrecord.app.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class DeleteToiletRecordUseCase {
+
+  private final ToiletRecordRepository toiletRecordRepository;
+
+  public void delete(Long userId, Long recordId) {
+    ToiletRecord record =
+        toiletRecordRepository
+            .findByUser_IdAndIdAndIsDeletedFalse(userId, recordId)
+            .orElseThrow(() -> new ServerException(ErrorCode.DATA_NOT_FOUND));
+    record.delete();
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/QueryToiletRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/QueryToiletRecordUseCase.java
@@ -1,0 +1,27 @@
+package depromeet.lessonfour.server.toiletrecord.app.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.toiletrecord.app.dto.response.ToiletRecordResponseDto;
+import depromeet.lessonfour.server.toiletrecord.app.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QueryToiletRecordUseCase {
+
+  private final ToiletRecordRepository toiletRecordRepository;
+
+  public ToiletRecordResponseDto getDetail(Long userId, Long recordId) {
+    ToiletRecord record =
+        toiletRecordRepository
+            .findByUser_IdAndIdAndIsDeletedFalse(userId, recordId)
+            .orElseThrow(() -> new ServerException(ErrorCode.DATA_NOT_FOUND));
+    return ToiletRecordResponseDto.of(record);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/UpdateToiletRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/app/service/UpdateToiletRecordUseCase.java
@@ -1,0 +1,40 @@
+package depromeet.lessonfour.server.toiletrecord.app.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.toiletrecord.app.dto.request.ToiletRecordUpdateRequestDto;
+import depromeet.lessonfour.server.toiletrecord.app.dto.response.ToiletRecordResponseDto;
+import depromeet.lessonfour.server.toiletrecord.app.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateToiletRecordUseCase {
+
+  private final ToiletRecordRepository toiletRecordRepository;
+
+  public ToiletRecordResponseDto update(
+      Long userId, Long recordId, ToiletRecordUpdateRequestDto dto) {
+    ToiletRecord record =
+        toiletRecordRepository
+            .findByUser_IdAndIdAndIsDeletedFalse(userId, recordId)
+            .orElseThrow(() -> new ServerException(ErrorCode.DATA_NOT_FOUND));
+
+    record.applyPatch(
+        dto.isSuccessful(),
+        dto.color(),
+        dto.shape(),
+        dto.pain(),
+        dto.duration(),
+        dto.note(),
+        dto.occurredAt());
+
+    // JPA dirty checking
+    return ToiletRecordResponseDto.of(record);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
@@ -67,6 +67,9 @@ public class ToiletRecord extends BaseTimeEntity {
   @Column(nullable = false)
   @NotNull private LocalDateTime occurredAt;
 
+  @Column(nullable = false)
+  @NotNull private boolean isDeleted;
+
   public static ToiletRecord register(
       User user,
       boolean isSuccessful,
@@ -85,6 +88,28 @@ public class ToiletRecord extends BaseTimeEntity {
         .duration(duration)
         .note(note)
         .occurredAt(occurredAt)
+        .isDeleted(false)
         .build();
+  }
+
+  public void applyPatch(
+      Boolean isSuccessful,
+      ToiletColor color,
+      ToiletShape shape,
+      Integer pain,
+      Integer duration,
+      String note,
+      LocalDateTime occurredAt) {
+    if (isSuccessful != null) this.isSuccessful = isSuccessful;
+    if (color != null) this.color = color;
+    if (shape != null) this.shape = shape;
+    if (pain != null) this.pain = pain;
+    if (duration != null) this.duration = duration;
+    if (note != null) this.note = note;
+    if (occurredAt != null) this.occurredAt = occurredAt;
+  }
+
+  public void delete() {
+    this.isDeleted = true;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/JpaToiletRecordRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/JpaToiletRecordRepository.java
@@ -1,0 +1,14 @@
+package depromeet.lessonfour.server.toiletrecord.infra.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+
+public interface JpaToiletRecordRepository extends JpaRepository<ToiletRecord, Long> {
+
+  Optional<ToiletRecord> findByUser_IdAndIdAndIsDeletedFalse(Long userId, Long recordId);
+
+  Optional<ToiletRecord> findByIdAndIsDeletedFalse(Long recordId);
+}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordRepository.java
@@ -1,7 +1,0 @@
-package depromeet.lessonfour.server.toiletrecord.infra.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
-
-public interface ToiletRecordRepository extends JpaRepository<ToiletRecord, Long> {}

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordRepositoryImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordRepositoryImpl.java
@@ -1,0 +1,31 @@
+package depromeet.lessonfour.server.toiletrecord.infra.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import depromeet.lessonfour.server.toiletrecord.app.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ToiletRecordRepositoryImpl implements ToiletRecordRepository {
+
+  private final JpaToiletRecordRepository jpa;
+
+  @Override
+  public void save(ToiletRecord record) {
+    jpa.save(record);
+  }
+
+  @Override
+  public Optional<ToiletRecord> findByUser_IdAndIdAndIsDeletedFalse(Long userId, Long recordId) {
+    return jpa.findByUser_IdAndIdAndIsDeletedFalse(userId, recordId);
+  }
+
+  @Override
+  public Optional<ToiletRecord> findByIdAndIsDeletedFalse(Long recordId) {
+    return jpa.findByIdAndIsDeletedFalse(recordId);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserQueryService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserQueryService.java
@@ -3,6 +3,8 @@ package depromeet.lessonfour.server.user.app.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.user.app.dto.response.UserResponseDto;
 import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.infra.repository.UserRepository;
@@ -19,5 +21,11 @@ public class UserQueryService {
     User user = userRepository.findByEmail(email).orElseThrow(RuntimeException::new);
 
     return UserResponseDto.of(user);
+  }
+
+  public User findById(Long userId) {
+    return userRepository
+        .findById(userId)
+        .orElseThrow(() -> new ServerException(ErrorCode.USER_NOT_FOUND));
   }
 }

--- a/src/main/resources/db/migration/V12__add_is_deleted_to_toilet_records.sql
+++ b/src/main/resources/db/migration/V12__add_is_deleted_to_toilet_records.sql
@@ -1,0 +1,2 @@
+alter table toilet_record
+    add column is_deleted boolean not null default false;


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #48 

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->
배변 기록(toiletrecord) CRUD를 DDD + 포트/어댑터 구조로 구현했습니다.
생활기록 crd와 동일한 레이어링/패턴을 적용했습니다.

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->
- Domain
  - ToiletRecord 엔티티에 isDeleted 추가 및 applyPatch(...), delete() 도입
- Repository (Port / Adapter)
  - app.repository.ToiletRecordRepository (Port) 추가
  - infra.repository.JpaToiletRecordRepository (JPA) 신설
    - 기존 ToiletRecordRepository extends JpaRepository 명 충돌 방지를 위해 클래스명 변경
  - infra.repository.ToiletRecordRepositoryImpl (Port 구현) 추가
  - 조회 메서드: findByUser_IdAndIdAndIsDeletedFalse(...) 중심으로 소유자 스코프 강제
- Application (UseCase)
  - CreateToiletRecordUseCase / UpdateToiletRecordUseCase /. DeleteToiletRecordUseCase / QueryToiletRecordUseCase
- API
  - ToiletRecordController에 UseCase 연동
- 마이그레이션(DDL)
  - toilet_record 테이블에 is_deleted 컬럼 추가 (기본값 false)

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->
- 주요 기능 구현

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->
- postman으로 local test 진행했습니다. 하단에 스크린샷 첨부합니다.

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->
### Create
<img width="744" height="705" alt="image" src="https://github.com/user-attachments/assets/5d73c1fe-556d-4346-a18c-27a67e489edd" />

### Read
<img width="733" height="481" alt="image" src="https://github.com/user-attachments/assets/59161b1d-7bdc-4060-b6bc-af20a4de5ae0" />

### Update
<img width="732" height="701" alt="image" src="https://github.com/user-attachments/assets/dbd8dc1b-d3d1-4564-a2b7-1bc6f86542c8" />

### Delete
<img width="732" height="292" alt="image" src="https://github.com/user-attachments/assets/3ee1eb7d-b61d-41f5-b641-9aedec8735b6" />

### 삭제 후 조회 시도 - 404 정상반환
<img width="430" height="298" alt="image" src="https://github.com/user-attachments/assets/7ac17670-177b-4963-9a60-570a010b79e3" />

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
- Flyway 마이그레이션: 태형님 PR의 V11을 확인하여 제 변경은 V12로 올렸습니다. 따라서 해당 PR이 먼저 머지되기 전에는 마이그레이션 버전 충돌이 발생할 수 있습니다.
- 의존성: 이번 PR은 태형님 PR의 UserQueryService(findById)를 전제로 합니다. 해당 PR이 머지되기 전에는 빌드가 실패합니다.
- 병합 순서상 태형님 PR(생활기록 CRD) 선머지 이후 본 PR을 머지해야합니다.

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 화장실 기록 생성/조회/수정/삭제 기능이 실제 데이터와 연동되어 동작합니다.
  * 기록 상세 조회 응답이 실제 저장된 내용으로 반환됩니다.
  * 소프트 삭제를 지원하여 삭제한 기록은 복구 가능성을 유지합니다.
* Bug Fixes
  * 삭제된 기록이 조회되지 않도록 차단했습니다.
  * 존재하지 않는 사용자/기록 요청 시 일관된 오류 응답을 제공합니다.
* Chores
  * 데이터베이스에 is_deleted 컬럼을 추가하는 마이그레이션을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->