### PR TITLE
[#71] fix : 일간 리포트 위험 음식 표시 수정

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/FoodMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/FoodMapper.java
@@ -68,7 +68,9 @@ public class FoodMapper {
             .map(
                 entry ->
                     new FoodReportMeal(
-                        entry.getKey(), foodEvaluation.isDangerous(), entry.getValue()))
+                        entry.getKey(),
+                        foodEvaluation.isMealDangerous(entry.getKey()),
+                        entry.getValue()))
             .collect(toList());
 
     return new FoodReportItem(getDate(foodEvaluation.getDayType()), meals);

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/FoodEvaluationPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/FoodEvaluationPolicy.java
@@ -2,6 +2,7 @@ package depromeet.lessonfour.server.report.domain.policy;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
@@ -26,11 +27,20 @@ public class FoodEvaluationPolicy {
                     FoodRecord::getMealTime,
                     Collectors.mapping(record -> record.getFood().getName(), Collectors.toList())));
 
-    return new FoodEvaluation(dangerous, foodsByMealTime, dayType);
+    Set<MealTime> dangerousMealTimes = getDangerousMealTimes(records);
+
+    return new FoodEvaluation(dangerous, foodsByMealTime, dayType, dangerousMealTimes);
   }
 
   private static boolean isDangerousExists(List<FoodRecord> records) {
     return records.stream()
         .anyMatch(record -> record.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD));
+  }
+
+  private static Set<MealTime> getDangerousMealTimes(List<FoodRecord> records) {
+    return records.stream()
+        .filter(record -> record.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD))
+        .map(FoodRecord::getMealTime)
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/FoodEvaluation.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/FoodEvaluation.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
 import lombok.Getter;
@@ -16,9 +17,13 @@ public class FoodEvaluation {
   private final DayType dayType;
   private final boolean dangerous;
   private final Map<MealTime, List<String>> foodsByMealTime;
+  private final Set<MealTime> dangerousMealTimes;
 
   public FoodEvaluation(
-      boolean dangerous, Map<MealTime, List<String>> foodsByMealTime, DayType dayType) {
+      boolean dangerous,
+      Map<MealTime, List<String>> foodsByMealTime,
+      DayType dayType,
+      Set<MealTime> dangerousMealTimes) {
     this.dangerous = dangerous;
     this.dayType = Objects.requireNonNull(dayType, "dayType must not be null");
     Map<MealTime, List<String>> source =
@@ -32,5 +37,11 @@ public class FoodEvaluation {
       copy.put(e.getKey(), list);
     }
     this.foodsByMealTime = Collections.unmodifiableMap(copy);
+    this.dangerousMealTimes =
+        dangerousMealTimes == null ? Collections.emptySet() : Set.copyOf(dangerousMealTimes);
+  }
+
+  public boolean isMealDangerous(MealTime mealTime) {
+    return dangerousMealTimes.contains(mealTime);
   }
 }


### PR DESCRIPTION
## Related Issue 🔗
- closes #71 

## Summary 📝
* MealTime에 따라 위험 음식이 있는지 판단하도록 수정

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<img width="824" height="651" alt="image" src="https://github.com/user-attachments/assets/fbf2a00d-eae2-4b7e-95ca-52775dfd028d" />

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 식사별 위험도 표시를 추가했습니다. 이제 리포트에서 각 끼니(예: 아침·점심·저녁 등)의 위험 여부가 개별적으로 판단되어 표시되어, 어떤 식사가 위험한지 한눈에 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->