### PR TITLE
Fix/생활기록을 만들 때 음식목록이 비어있거나 null인 경우에도 생성 허용

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/request/CreateActivityRecordsRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record CreateActivityRecordsRequest(
-    @Valid @NotNull(message = "음식 목록은 필수입니다") List<CreateFoodRequestDto> foods,
+    @Valid List<CreateFoodRequestDto> foods,
     @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int water,
     @NotNull(message = "스트레스 지수는 필수입니다") @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
         StressLevel stress,

--- a/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
@@ -189,7 +189,7 @@ class CreateActivityRecordE2ETest {
 
   @Test
   @DisplayName("음식 목록이 null인 경우에도 기록을 생성할 수 있다")
-  void givenNullSelectedFoods_whenCreateActivityRecord_thenBadRequest() {
+  void givenNullSelectedFoods_whenCreateActivityRecord_thenSuccess() {
     LocalDateTime now = LocalDateTime.now();
     String createRequest =
         String.format(

--- a/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
@@ -188,7 +188,7 @@ class CreateActivityRecordE2ETest {
   }
 
   @Test
-  @DisplayName("음식 목록이 null인 경우 400 에러를 반환한다")
+  @DisplayName("음식 목록이 null인 경우에도 기록을 생성할 수 있다")
   void givenNullSelectedFoods_whenCreateActivityRecord_thenBadRequest() {
     LocalDateTime now = LocalDateTime.now();
     String createRequest =
@@ -210,9 +210,35 @@ class CreateActivityRecordE2ETest {
         .when()
         .post("/api/v1/activity-records")
         .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("음식 목록은 필수입니다"));
+        .statusCode(HttpStatus.CREATED.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE);
+  }
+
+  @Test
+  @DisplayName("음식 목록이 빈 배열인 경우에도 기록을 생성할 수 있다")
+  void givenEmptySelectedFoods_whenCreateActivityRecord_thenBadRequest() {
+    LocalDateTime now = LocalDateTime.now();
+    String createRequest =
+        String.format(
+            """
+        {
+          "foods": [],
+          "water": 3,
+          "stress": "LOW",
+          "occurredAt": "%s"
+        }
+        """,
+            now.format(formatter));
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(createRequest)
+        .when()
+        .post("/api/v1/activity-records")
+        .then()
+        .statusCode(HttpStatus.CREATED.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE);
   }
 
   @Test


### PR DESCRIPTION
## Related Issue 🔗
- closes #77

## Summary 📝
* 생활기록을 만들 때 음식 목록이 비어있거나 Null인 경우에도 생성 허용

## Changes ✨
* CreateActivityRecordDto 제약 조건 삭제

## Why we need 💡
* 음식목록 없이도 물이나 스트레스 지수만으로도 생활기록을 생성 가능

## Test 🧪
* e2e test 추가

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 활동 기록 생성 시 음식 목록을 비우거나 아예 생략해도 정상 생성(HTTP 201)되도록 입력 유연성을 개선했습니다.
* 테스트
  * 기존 E2E 시나리오를 최신 동작에 맞게 변경(음식 누락 시 성공 기대)했고, 음식이 빈 배열인 경우를 검증하는 케이스를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->