### PR TITLE
Feature/auth code flow

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -44,18 +44,17 @@ public class KakaoAuthController {
   @Value("${kakao.auth-url}")
   private String kakaoAuthUrl;
 
-  @Value("${kakao.callback-mode:token}")
-  private String callbackMode;
-
   public KakaoAuthController(KakaoAuthService kakaoAuthService) {
     this.kakaoAuthService = kakaoAuthService;
   }
 
   @Operation(summary = "카카오 로그인", description = "카카오를 통해 로그인을 진행합니다.")
   @PostMapping("/login")
-  public ResponseEntity<Void> kakaoLogin(@RequestParam(required = false) String redirectUri) {
+  public ResponseEntity<Void> kakaoLogin(
+      @RequestParam(required = false) String redirectUri,
+      @RequestParam(required = false) String responseType) {
     String authUrl =
-        kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl);
+        kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl, responseType);
     return ResponseEntity.status(302).header("Location", authUrl).build();
   }
 
@@ -89,7 +88,27 @@ public class KakaoAuthController {
       @RequestParam(required = false) String code,
       @RequestParam(required = false) String error,
       @RequestParam(required = false) String state) {
-    String clientRedirectUri = state != null ? state : frontendUrl;
+    
+    // state에서 redirectUri와 responseType 파싱
+    String clientRedirectUri = frontendUrl;
+    String requestResponseType = null;
+    
+    if (state != null && !state.isBlank()) {
+      String[] stateParts = state.split("\\|responseType=", 2); // 최대 2개로 분할
+      
+      // redirectUri 파싱 (첫 번째 부분)
+      String parsedRedirectUri = stateParts[0];
+      if (parsedRedirectUri != null && !parsedRedirectUri.isBlank()) {
+        clientRedirectUri = parsedRedirectUri;
+      }
+      // parsedRedirectUri가 빈 문자열이면 기본값(frontendUrl) 유지
+      
+      // responseType 파싱 (두 번째 부분)
+      if (stateParts.length > 1 && stateParts[1] != null && !stateParts[1].isBlank()) {
+        requestResponseType = stateParts[1];
+      }
+    }
+    
     if (error != null) {
       String errorUrl =
           UriComponentsBuilder.fromUriString(clientRedirectUri)
@@ -102,8 +121,8 @@ public class KakaoAuthController {
 
     if (code != null) {
       try {
-        // 콜백 모드에 따라 다르게 처리
-        if ("code".equals(callbackMode)) {
+        // responseType이 "code"인 경우에만 auth code를 그대로 전달, 그 외에는 토큰 직접 발급
+        if ("code".equals(requestResponseType)) {
           // auth code를 그대로 프론트엔드로 전달
           String successUrl =
               UriComponentsBuilder.fromUriString(clientRedirectUri)
@@ -117,7 +136,7 @@ public class KakaoAuthController {
               .cacheControl(CacheControl.noStore().mustRevalidate())
               .build();
         } else {
-          // 기존 방식: 토큰 직접 발급
+          // 기본 방식: 토큰 직접 발급 (responseType이 없거나 "code"가 아닌 경우)
           AuthResponseDto authResult = kakaoAuthService.login(code);
 
           // redirectUrl의 호스트를 도메인으로 사용

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -5,15 +5,19 @@ import java.nio.charset.StandardCharsets;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import depromeet.lessonfour.server.auth.api.dto.KakaoTokenRequestDto;
 import depromeet.lessonfour.server.auth.api.util.RefreshTokenCookieGenerator;
 import depromeet.lessonfour.server.auth.app.service.KakaoAuthService;
 import depromeet.lessonfour.server.user.app.dto.response.AuthResponseDto;
@@ -40,6 +44,9 @@ public class KakaoAuthController {
   @Value("${kakao.auth-url}")
   private String kakaoAuthUrl;
 
+  @Value("${kakao.callback-mode:token}")
+  private String callbackMode;
+
   public KakaoAuthController(KakaoAuthService kakaoAuthService) {
     this.kakaoAuthService = kakaoAuthService;
   }
@@ -50,6 +57,30 @@ public class KakaoAuthController {
     String authUrl =
         kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl);
     return ResponseEntity.status(302).header("Location", authUrl).build();
+  }
+
+  @Operation(
+      summary = "카카오 인증 토큰 발급",
+      description = "카카오 인증 코드를 받아서 토큰을 JSON 형태로 반환합니다.")
+  @PostMapping("/token")
+  public ResponseEntity<AuthResponseDto> getKakaoToken(@RequestBody KakaoTokenRequestDto request) {
+    try {
+      AuthResponseDto authResult = kakaoAuthService.login(request.code());
+      
+      // redirectUri가 제공된 경우 응답에 포함 (프론트엔드에서 활용 가능)
+      if (request.redirectUri() != null && !request.redirectUri().isBlank()) {
+        return ResponseEntity.ok()
+            .cacheControl(CacheControl.noStore().mustRevalidate())
+            .header("X-Redirect-Uri", request.redirectUri())
+            .body(authResult);
+      }
+      
+      return ResponseEntity.ok()
+          .cacheControl(CacheControl.noStore().mustRevalidate())
+          .body(authResult);
+    } catch (Exception e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Authentication failed: " + e.getMessage());
+    }
   }
 
   @Hidden
@@ -71,50 +102,67 @@ public class KakaoAuthController {
 
     if (code != null) {
       try {
-        AuthResponseDto authResult = kakaoAuthService.login(code);
+        // 콜백 모드에 따라 다르게 처리
+        if ("code".equals(callbackMode)) {
+          // auth code를 그대로 프론트엔드로 전달
+          String successUrl =
+              UriComponentsBuilder.fromUriString(clientRedirectUri)
+                  .queryParam("code", code)
+                  .encode(StandardCharsets.UTF_8)
+                  .build()
+                  .toUriString();
 
-        // redirectUrl의 호스트를 도메인으로 사용
-        String domain = null;
-        try {
-          URI redirectUri = URI.create(clientRedirectUri);
-          domain = redirectUri.getHost();
-        } catch (Exception e) {
-          // URI 파싱 실패 시 도메인 없이 진행
-        }
-
-        String successUrl =
-            UriComponentsBuilder.fromUriString(clientRedirectUri)
-                .queryParam("id", authResult.id())
-                .queryParam("nickname", authResult.nickname())
-                .queryParam("profileImage", authResult.profileImage())
-                .queryParam("isNew", authResult.isNew())
-                .queryParam("providerType", authResult.provider().getType())
-                .encode(StandardCharsets.UTF_8)
-                .build()
-                .toUriString();
-
-        ResponseEntity.BodyBuilder responseBuilder =
-            ResponseEntity.status(302)
-                .header("Location", successUrl)
-                .cacheControl(CacheControl.noStore().mustRevalidate());
-
-        // 도메인을 성공적으로 가져올 수 있으면 2개 쿠키 생성
-        if (domain != null && !domain.isBlank()) {
-          ResponseCookie refreshTokenCookieWithDomain =
-              RefreshTokenCookieGenerator.generate(authResult.refreshToken(), domain);
-          ResponseCookie refreshTokenCookieWithoutDomain =
-              RefreshTokenCookieGenerator.generate(authResult.refreshToken());
-
-          return responseBuilder
-              .header("Set-Cookie", refreshTokenCookieWithDomain.toString())
-              .header("Set-Cookie", refreshTokenCookieWithoutDomain.toString())
+          return ResponseEntity.status(302)
+              .header("Location", successUrl)
+              .cacheControl(CacheControl.noStore().mustRevalidate())
               .build();
         } else {
-          // 도메인을 가져올 수 없으면 1개 쿠키만 생성
-          ResponseCookie refreshTokenCookie =
-              RefreshTokenCookieGenerator.generate(authResult.refreshToken());
+          // 기존 방식: 토큰 직접 발급
+          AuthResponseDto authResult = kakaoAuthService.login(code);
 
-          return responseBuilder.header("Set-Cookie", refreshTokenCookie.toString()).build();
+          // redirectUrl의 호스트를 도메인으로 사용
+          String domain = null;
+          try {
+            URI redirectUri = URI.create(clientRedirectUri);
+            domain = redirectUri.getHost();
+          } catch (Exception e) {
+            // URI 파싱 실패 시 도메인 없이 진행
+          }
+
+          String successUrl =
+              UriComponentsBuilder.fromUriString(clientRedirectUri)
+                  .queryParam("id", authResult.id())
+                  .queryParam("nickname", authResult.nickname())
+                  .queryParam("profileImage", authResult.profileImage())
+                  .queryParam("isNew", authResult.isNew())
+                  .queryParam("providerType", authResult.provider().getType())
+                  .encode(StandardCharsets.UTF_8)
+                  .build()
+                  .toUriString();
+
+          ResponseEntity.BodyBuilder responseBuilder =
+              ResponseEntity.status(302)
+                  .header("Location", successUrl)
+                  .cacheControl(CacheControl.noStore().mustRevalidate());
+
+          // 도메인을 성공적으로 가져올 수 있으면 2개 쿠키 생성
+          if (domain != null && !domain.isBlank()) {
+            ResponseCookie refreshTokenCookieWithDomain =
+                RefreshTokenCookieGenerator.generate(authResult.refreshToken(), domain);
+            ResponseCookie refreshTokenCookieWithoutDomain =
+                RefreshTokenCookieGenerator.generate(authResult.refreshToken());
+
+            return responseBuilder
+                .header("Set-Cookie", refreshTokenCookieWithDomain.toString())
+                .header("Set-Cookie", refreshTokenCookieWithoutDomain.toString())
+                .build();
+          } else {
+            // 도메인을 가져올 수 없으면 1개 쿠키만 생성
+            ResponseCookie refreshTokenCookie =
+                RefreshTokenCookieGenerator.generate(authResult.refreshToken());
+
+            return responseBuilder.header("Set-Cookie", refreshTokenCookie.toString()).build();
+          }
         }
 
       } catch (Exception e) {

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -66,14 +66,6 @@ public class KakaoAuthController {
       // JSON 응답에서는 access token도 포함
       AuthResponseDto authResult = kakaoAuthService.login(request.code(), true);
 
-      // redirectUri가 제공된 경우 응답에 포함 (프론트엔드에서 활용 가능)
-      if (request.redirectUri() != null && !request.redirectUri().isBlank()) {
-        return ResponseEntity.ok()
-            .cacheControl(CacheControl.noStore().mustRevalidate())
-            .header("X-Redirect-Uri", request.redirectUri())
-            .body(authResult);
-      }
-
       return ResponseEntity.ok()
           .cacheControl(CacheControl.noStore().mustRevalidate())
           .body(authResult);

--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/KakaoAuthController.java
@@ -54,18 +54,18 @@ public class KakaoAuthController {
       @RequestParam(required = false) String redirectUri,
       @RequestParam(required = false) String responseType) {
     String authUrl =
-        kakaoAuthService.getRequestUrl(redirectUri != null ? redirectUri : frontendUrl, responseType);
+        kakaoAuthService.getRequestUrl(
+            redirectUri != null ? redirectUri : frontendUrl, responseType);
     return ResponseEntity.status(302).header("Location", authUrl).build();
   }
 
-  @Operation(
-      summary = "카카오 인증 토큰 발급",
-      description = "카카오 인증 코드를 받아서 토큰을 JSON 형태로 반환합니다.")
+  @Operation(summary = "카카오 인증 토큰 발급", description = "카카오 인증 코드를 받아서 토큰을 JSON 형태로 반환합니다.")
   @PostMapping("/token")
   public ResponseEntity<AuthResponseDto> getKakaoToken(@RequestBody KakaoTokenRequestDto request) {
     try {
-      AuthResponseDto authResult = kakaoAuthService.login(request.code());
-      
+      // JSON 응답에서는 access token도 포함
+      AuthResponseDto authResult = kakaoAuthService.login(request.code(), true);
+
       // redirectUri가 제공된 경우 응답에 포함 (프론트엔드에서 활용 가능)
       if (request.redirectUri() != null && !request.redirectUri().isBlank()) {
         return ResponseEntity.ok()
@@ -73,12 +73,13 @@ public class KakaoAuthController {
             .header("X-Redirect-Uri", request.redirectUri())
             .body(authResult);
       }
-      
+
       return ResponseEntity.ok()
           .cacheControl(CacheControl.noStore().mustRevalidate())
           .body(authResult);
     } catch (Exception e) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Authentication failed: " + e.getMessage());
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "Authentication failed: " + e.getMessage());
     }
   }
 
@@ -88,27 +89,27 @@ public class KakaoAuthController {
       @RequestParam(required = false) String code,
       @RequestParam(required = false) String error,
       @RequestParam(required = false) String state) {
-    
+
     // state에서 redirectUri와 responseType 파싱
     String clientRedirectUri = frontendUrl;
     String requestResponseType = null;
-    
+
     if (state != null && !state.isBlank()) {
       String[] stateParts = state.split("\\|responseType=", 2); // 최대 2개로 분할
-      
+
       // redirectUri 파싱 (첫 번째 부분)
       String parsedRedirectUri = stateParts[0];
       if (parsedRedirectUri != null && !parsedRedirectUri.isBlank()) {
         clientRedirectUri = parsedRedirectUri;
       }
       // parsedRedirectUri가 빈 문자열이면 기본값(frontendUrl) 유지
-      
+
       // responseType 파싱 (두 번째 부분)
       if (stateParts.length > 1 && stateParts[1] != null && !stateParts[1].isBlank()) {
         requestResponseType = stateParts[1];
       }
     }
-    
+
     if (error != null) {
       String errorUrl =
           UriComponentsBuilder.fromUriString(clientRedirectUri)

--- a/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
@@ -1,3 +1,3 @@
 package depromeet.lessonfour.server.auth.api.dto;
 
-public record KakaoTokenRequestDto(String code, String redirectUri) {}
+public record KakaoTokenRequestDto(String code) {}

--- a/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
@@ -1,0 +1,6 @@
+package depromeet.lessonfour.server.auth.api.dto;
+
+public record KakaoTokenRequestDto(
+    String code,
+    String redirectUri
+) {}

--- a/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/dto/KakaoTokenRequestDto.java
@@ -1,6 +1,3 @@
 package depromeet.lessonfour.server.auth.api.dto;
 
-public record KakaoTokenRequestDto(
-    String code,
-    String redirectUri
-) {}
+public record KakaoTokenRequestDto(String code, String redirectUri) {}

--- a/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
@@ -67,7 +67,7 @@ public class KakaoAuthService {
     this.authUrl = authUrl;
   }
 
-  public AuthResponseDto login(String code) {
+  public AuthResponseDto login(String code, boolean includeAccessToken) {
     if (code != null) {
       Map<String, Object> tokenData = getToken(code);
       String idToken = tokenData.get("id_token").toString();
@@ -76,17 +76,29 @@ public class KakaoAuthService {
       }
 
       User user = getUserFromToken(idToken);
-      return AuthResponseDto.of(UserResponseDto.of(user), null, user.getRefreshToken());
+
+      // includeAccessToken이 true일 때만 access token 발급
+      String accessToken = null;
+      if (includeAccessToken) {
+        AccountContext accountContext = AccountContext.of(user);
+        accessToken = jwtTokenGenerator.generateAccessToken(accountContext);
+      }
+
+      return AuthResponseDto.of(UserResponseDto.of(user), accessToken, user.getRefreshToken());
     }
     throw new ServerException(AuthErrorCode.LOGIN_CODE_REQUIRED);
+  }
+
+  public AuthResponseDto login(String code) {
+    return login(code, false); // 기본값은 false
   }
 
   public String getRequestUrl(String clientRedirectUri, String responseType) {
     // state에 redirectUri와 responseType을 함께 인코딩
     // redirectUri가 null이면 빈 문자열로 처리
-    String safeRedirectUri = (clientRedirectUri != null && !clientRedirectUri.isBlank()) 
-        ? clientRedirectUri : "";
-    
+    String safeRedirectUri =
+        (clientRedirectUri != null && !clientRedirectUri.isBlank()) ? clientRedirectUri : "";
+
     final String stateValue;
     if (responseType != null && !responseType.isBlank()) {
       // responseType이 있는 경우: "redirectUri|responseType=value" 형태
@@ -95,7 +107,7 @@ public class KakaoAuthService {
       // responseType이 없는 경우: redirectUri만 또는 빈 문자열
       stateValue = safeRedirectUri;
     }
-    
+
     MultiValueMap<String, String> authParams =
         new LinkedMultiValueMap<>() {
           {
@@ -111,7 +123,7 @@ public class KakaoAuthService {
         .build()
         .toUriString();
   }
-  
+
   public String getRequestUrl(String clientRedirectUri) {
     return getRequestUrl(clientRedirectUri, null);
   }

--- a/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/app/service/KakaoAuthService.java
@@ -81,13 +81,27 @@ public class KakaoAuthService {
     throw new ServerException(AuthErrorCode.LOGIN_CODE_REQUIRED);
   }
 
-  public String getRequestUrl(String clientRedirectUri) {
+  public String getRequestUrl(String clientRedirectUri, String responseType) {
+    // state에 redirectUri와 responseType을 함께 인코딩
+    // redirectUri가 null이면 빈 문자열로 처리
+    String safeRedirectUri = (clientRedirectUri != null && !clientRedirectUri.isBlank()) 
+        ? clientRedirectUri : "";
+    
+    final String stateValue;
+    if (responseType != null && !responseType.isBlank()) {
+      // responseType이 있는 경우: "redirectUri|responseType=value" 형태
+      stateValue = safeRedirectUri + "|responseType=" + responseType;
+    } else {
+      // responseType이 없는 경우: redirectUri만 또는 빈 문자열
+      stateValue = safeRedirectUri;
+    }
+    
     MultiValueMap<String, String> authParams =
         new LinkedMultiValueMap<>() {
           {
             add("client_id", clientId);
             add("redirect_uri", redirectUri); // serverRedirectUri
-            add("state", clientRedirectUri);
+            add("state", stateValue);
             add("response_type", "code");
             add("scope", "openid profile_nickname profile_image account_email");
           }
@@ -96,6 +110,10 @@ public class KakaoAuthService {
         .queryParams(authParams)
         .build()
         .toUriString();
+  }
+  
+  public String getRequestUrl(String clientRedirectUri) {
+    return getRequestUrl(clientRedirectUri, null);
   }
 
   private Map<String, Object> getToken(String code) {

--- a/src/main/java/depromeet/lessonfour/server/common/api/code/ErrorCode.java
+++ b/src/main/java/depromeet/lessonfour/server/common/api/code/ErrorCode.java
@@ -26,6 +26,11 @@ public enum ErrorCode implements BaseErrorCode {
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
 
   /*
+  403 FORBIDDEN
+  */
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+  /*
   404 NOT FOUND
   */
   DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않습니다"),

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -1,0 +1,48 @@
+package depromeet.lessonfour.server.user.api.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.api.code.SuccessCode;
+import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.user.app.dto.response.UserProfileResponseDto;
+import depromeet.lessonfour.server.user.app.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "사용자", description = "사용자 관련 API 문서입니다.")
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+  private final UserQueryService userQueryService;
+
+  public UserController(UserQueryService userQueryService) {
+    this.userQueryService = userQueryService;
+  }
+
+  @Operation(
+      summary = "사용자 정보 조회",
+      description = "지정된 ID의 사용자 정보를 조회합니다. 본인의 정보만 조회할 수 있습니다.",
+      security = {@SecurityRequirement(name = "JWT")})
+  @GetMapping("/{userId}")
+  public ResponseEntity<SuccessResponse<UserProfileResponseDto>> getUser(
+      @PathVariable Long userId,
+      @AuthenticationPrincipal(expression = "id") Long authenticatedUserId) {
+
+    // 요청한 사용자 ID와 인증된 사용자 ID가 일치하는지 확인
+    if (!userId.equals(authenticatedUserId)) {
+      throw new ServerException(ErrorCode.ACCESS_DENIED);
+    }
+
+    UserProfileResponseDto user = UserProfileResponseDto.of(userQueryService.findById(userId));
+    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, user));
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -29,6 +29,18 @@ public class UserController {
   }
 
   @Operation(
+      summary = "내 정보 조회",
+      description = "현재 로그인한 사용자의 정보를 조회합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
+  @GetMapping("/me")
+  public ResponseEntity<SuccessResponse<UserProfileResponseDto>> getMe(
+      @AuthenticationPrincipal(expression = "id") Long authenticatedUserId) {
+
+    UserProfileResponseDto user = UserProfileResponseDto.of(userQueryService.findById(authenticatedUserId));
+    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, user));
+  }
+
+  @Operation(
       summary = "사용자 정보 조회",
       description = "지정된 ID의 사용자 정보를 조회합니다. 본인의 정보만 조회할 수 있습니다.",
       security = {@SecurityRequirement(name = "JWT")})

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -36,7 +36,8 @@ public class UserController {
   public ResponseEntity<SuccessResponse<UserProfileResponseDto>> getMe(
       @AuthenticationPrincipal(expression = "id") Long authenticatedUserId) {
 
-    UserProfileResponseDto user = UserProfileResponseDto.of(userQueryService.findById(authenticatedUserId));
+    UserProfileResponseDto user =
+        UserProfileResponseDto.of(userQueryService.findById(authenticatedUserId));
     return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, user));
   }
 

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UserProfileResponseDto.java
@@ -1,0 +1,11 @@
+package depromeet.lessonfour.server.user.app.dto.response;
+
+import depromeet.lessonfour.server.user.domain.entity.User;
+
+public record UserProfileResponseDto(Long id, String email, String nickname, String profileImage) {
+
+  public static UserProfileResponseDto of(User user) {
+    return new UserProfileResponseDto(
+        user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage());
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,7 +45,6 @@ kakao:
   issuer-url: ${KAKAO__ISSUER_URL:https://kauth.kakao.com}
   auth-url: ${KAKAO__AUTH_URL:https://kauth.kakao.com/oauth/authorize}
   token-url: ${KAKAO__TOKEN_URL:https://kauth.kakao.com/oauth/token}
-  callback-mode: ${KAKAO__CALLBACK_MODE:token} # token: 토큰 직접 발급, code: auth code 전달
 
 frontend:
   url: ${FRONTEND__URL:http://localhost:3000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -45,6 +45,7 @@ kakao:
   issuer-url: ${KAKAO__ISSUER_URL:https://kauth.kakao.com}
   auth-url: ${KAKAO__AUTH_URL:https://kauth.kakao.com/oauth/authorize}
   token-url: ${KAKAO__TOKEN_URL:https://kauth.kakao.com/oauth/token}
+  callback-mode: ${KAKAO__CALLBACK_MODE:token} # token: 토큰 직접 발급, code: auth code 전달
 
 frontend:
   url: ${FRONTEND__URL:http://localhost:3000}

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -58,7 +58,13 @@ async def home(request: Request):
         <div class="auth-code-info">
             <h2>받은 Auth Code</h2>
             <div class="code-display">{auth_code}</div>
-            <button onclick="getTokenFromCode('{auth_code}')" class="token-btn">이 코드로 토큰 발급받기</button>
+            <button onclick="getTokenFromCode('{auth_code}')" class="token-btn" style="margin-top: 15px;">2단계: Get Token</button>
+            
+            <div id="codeTokenInfo" class="token-info" style="display: none; margin-top: 15px;">
+                <h3>Auth Code Flow 결과</h3>
+                <div id="codeTokenDisplay"></div>
+                <div id="userInfoFromToken" style="margin-top: 15px;"></div>
+            </div>
         </div>
         """
     
@@ -206,6 +212,20 @@ async def home(request: Request):
             <h3>토큰 직접 발급 방식</h3>
             <p style="margin-bottom: 15px; color: #666;">카카오 인증 후 바로 토큰을 발급받아 쿠키로 설정</p>
             <button onclick="loginWithResponseType()" class="login-btn">카카오로 로그인 (토큰 방식)</button>
+            
+            <div class="token-section" style="margin-top: 20px;">
+                <div class="token-input-group">
+                    <button onclick="getToken()" class="token-btn">Get Access Token</button>
+                </div>
+                <p style="margin-top: 10px; color: #666; font-size: 14px;">
+                    쿠키의 refresh token으로 access token을 발급받습니다.
+                </p>
+                
+                <div id="tokenInfo" class="token-info" style="display: none; margin-top: 15px;">
+                    <h3>Access Token</h3>
+                    <div id="tokenDisplay" class="token-display"></div>
+                </div>
+            </div>
         </div>
         
         <div class="auth-flow-section">
@@ -217,34 +237,9 @@ async def home(request: Request):
                     💡 responseType=code로 설정하면 auth code만 받습니다
                 </p>
             </div>
-            <div style="margin: 15px 0;">
-                <input type="text" id="manualCodeInput" placeholder="또는 여기에 auth code를 직접 입력하세요" 
-                       style="width: 300px; padding: 10px; margin-right: 10px; border: 1px solid #ddd; border-radius: 4px;">
-                <button onclick="getTokenFromManualCode()" class="token-btn">2단계: Get Token</button>
-            </div>
-        </div>
-        
-        <div class="token-section">
-            <div class="token-input-group">
-                <button onclick="getToken()" class="token-btn">Get token</button>
-            </div>
-            <p style="margin-top: 10px; color: #666; font-size: 14px;">
-                Refresh token은 쿠키에서 자동으로 가져옵니다.
-            </p>
         </div>
         {user_info_section}
         {auth_code_section}
-        
-        <div id="tokenInfo" class="token-info" style="display: none;">
-            <h3>Access Token</h3>
-            <div id="tokenDisplay" class="token-display"></div>
-        </div>
-        
-        <div id="codeTokenInfo" class="token-info" style="display: none;">
-            <h3>Auth Code로 발급받은 토큰</h3>
-            <div id="codeTokenDisplay" class="token-display"></div>
-            <div id="userInfoFromToken" style="margin-top: 15px;"></div>
-        </div>
         
         <script>
             async function getToken() {{
@@ -305,7 +300,19 @@ async def home(request: Request):
                     
                     if (response.ok) {{
                         const data = await response.json();
-                        document.getElementById('codeTokenDisplay').textContent = data.refreshToken || 'No token received';
+                        
+                        // 토큰 정보 표시
+                        const tokenInfoHtml = `
+                            <p><strong>Access Token:</strong></p>
+                            <div style="word-break: break-all; font-family: monospace; background-color: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0;">
+                                ${{data.accessToken || 'No access token'}}
+                            </div>
+                            <p><strong>Refresh Token:</strong></p>
+                            <div style="word-break: break-all; font-family: monospace; background-color: #f8f9fa; padding: 10px; border-radius: 4px; margin: 10px 0;">
+                                ${{data.refreshToken || 'No refresh token'}}
+                            </div>
+                        `;
+                        document.getElementById('codeTokenDisplay').innerHTML = tokenInfoHtml;
                         
                         // 사용자 정보 표시
                         const userInfoHtml = `
@@ -327,14 +334,6 @@ async def home(request: Request):
                 }}
             }}
             
-            async function getTokenFromManualCode() {{
-                const code = document.getElementById('manualCodeInput').value.trim();
-                if (!code) {{
-                    alert('Auth code를 입력해주세요.');
-                    return;
-                }}
-                await getTokenFromCode(code);
-            }}
         </script>
     </body>
     </html>

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -286,15 +286,13 @@ async def home(request: Request):
             
             async function getTokenFromCode(code) {{
                 try {{
-                    const redirectUri = 'http://localhost:{SERVICE_PORT}';
                     const response = await fetch(`{SERVER_URL}/api/v1/auth/kakao/token`, {{
                         method: 'POST',
                         headers: {{
                             'Content-Type': 'application/json',
                         }},
                         body: JSON.stringify({{
-                            code: code,
-                            redirectUri: redirectUri
+                            code: code
                         }})
                     }});
                     

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -29,6 +29,9 @@ async def home(request: Request):
     is_new = request.query_params.get("isNew")
     provider_type = request.query_params.get("providerType")
     
+    # auth code 추출 (새로운 플로우용)
+    auth_code = request.query_params.get("code")
+    
     # 사용자 정보가 있는지 확인
     has_user_info = any([user_id, nickname, profile_image])
     
@@ -45,6 +48,17 @@ async def home(request: Request):
                 {f'<p><strong>신규 사용자:</strong> {is_new}</p>' if is_new else ''}
                 {f'<p><strong>제공자:</strong> {provider_type}</p>' if provider_type else ''}
             </div>
+        </div>
+        """
+    
+    # auth code 섹션 HTML 생성
+    auth_code_section = ""
+    if auth_code:
+        auth_code_section = f"""
+        <div class="auth-code-info">
+            <h2>받은 Auth Code</h2>
+            <div class="code-display">{auth_code}</div>
+            <button onclick="getTokenFromCode('{auth_code}')" class="token-btn">이 코드로 토큰 발급받기</button>
         </div>
         """
     
@@ -140,14 +154,76 @@ async def home(request: Request):
                 border-radius: 4px;
                 margin-top: 10px;
             }}
+            .auth-code-info {{
+                margin-top: 30px;
+                padding: 20px;
+                background-color: #fff3cd;
+                border-radius: 8px;
+                border-left: 4px solid #ffc107;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+            }}
+            .code-display {{
+                word-break: break-all;
+                font-family: monospace;
+                background-color: #f8f9fa;
+                padding: 15px;
+                border-radius: 4px;
+                margin: 15px 0;
+                border: 1px solid #ddd;
+            }}
+            .auth-flow-section {{
+                margin-top: 30px;
+                padding: 20px;
+                background-color: #e8f5e8;
+                border-radius: 8px;
+                border-left: 4px solid #28a745;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+            }}
+            .success-btn {{
+                background-color: #28a745; 
+                color: #fff; 
+                padding: 15px 30px; 
+                border: none; 
+                border-radius: 8px; 
+                font-size: 16px; 
+                cursor: pointer; 
+                text-decoration: none;
+                display: inline-block;
+                margin: 10px;
+            }}
+            .success-btn:hover {{ background-color: #218838; }}
         </style>
     </head>
     <body>
         <h1>카카오 OAuth 로그인 테스트</h1>
         <p>아래 버튼을 클릭하여 카카오로 로그인하세요</p>
-        <form action="{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=http://localhost:{SERVICE_PORT}" method="post" style="display:inline;">
-            <button type="submit" class="login-btn">카카오로 로그인</button>
-        </form>
+        
+        <div style="margin: 20px 0;">
+            <h3>기존 방식 (토큰 직접 발급)</h3>
+            <form action="{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=http://localhost:{SERVICE_PORT}" method="post" style="display:inline;">
+                <button type="submit" class="login-btn">카카오로 로그인</button>
+            </form>
+        </div>
+        
+        <div class="auth-flow-section">
+            <h3>새로운 방식 (Auth Code Flow)</h3>
+            <p style="margin-bottom: 15px; color: #666;">1단계: Auth Code 받기 → 2단계: Code로 토큰 발급</p>
+            <div style="margin: 15px 0;">
+                <button onclick="getAuthCode()" class="success-btn">1단계: Get Auth Code</button>
+                <p style="margin: 10px 0; font-size: 14px; color: #666;">
+                    ⚠️ 서버의 callback-mode가 'code'로 설정되어 있어야 합니다
+                </p>
+            </div>
+            <div style="margin: 15px 0;">
+                <input type="text" id="manualCodeInput" placeholder="또는 여기에 auth code를 직접 입력하세요" 
+                       style="width: 300px; padding: 10px; margin-right: 10px; border: 1px solid #ddd; border-radius: 4px;">
+                <button onclick="getTokenFromManualCode()" class="token-btn">2단계: Get Token</button>
+            </div>
+        </div>
         
         <div class="token-section">
             <div class="token-input-group">
@@ -158,10 +234,17 @@ async def home(request: Request):
             </p>
         </div>
         {user_info_section}
+        {auth_code_section}
         
         <div id="tokenInfo" class="token-info" style="display: none;">
             <h3>Access Token</h3>
             <div id="tokenDisplay" class="token-display"></div>
+        </div>
+        
+        <div id="codeTokenInfo" class="token-info" style="display: none;">
+            <h3>Auth Code로 발급받은 토큰</h3>
+            <div id="codeTokenDisplay" class="token-display"></div>
+            <div id="userInfoFromToken" style="margin-top: 15px;"></div>
         </div>
         
         <script>
@@ -186,6 +269,67 @@ async def home(request: Request):
                 }} catch (error) {{
                     alert('토큰 가져오기 중 오류 발생: ' + error.message);
                 }}
+            }}
+            
+            function getAuthCode() {{
+                // Auth Code 플로우를 위해 새 창에서 카카오 로그인 시작
+                const redirectUri = encodeURIComponent('http://localhost:{SERVICE_PORT}');
+                const loginUrl = '{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=' + redirectUri;
+                
+                // POST 요청을 위한 form 생성 및 제출
+                const form = document.createElement('form');
+                form.method = 'POST';
+                form.action = loginUrl;
+                form.target = '_self';
+                document.body.appendChild(form);
+                form.submit();
+            }}
+            
+            async function getTokenFromCode(code) {{
+                try {{
+                    const redirectUri = 'http://localhost:{SERVICE_PORT}';
+                    const response = await fetch(`{SERVER_URL}/api/v1/auth/kakao/token`, {{
+                        method: 'POST',
+                        headers: {{
+                            'Content-Type': 'application/json',
+                        }},
+                        body: JSON.stringify({{
+                            code: code,
+                            redirectUri: redirectUri
+                        }})
+                    }});
+                    
+                    if (response.ok) {{
+                        const data = await response.json();
+                        document.getElementById('codeTokenDisplay').textContent = data.refreshToken || 'No token received';
+                        
+                        // 사용자 정보 표시
+                        const userInfoHtml = `
+                            <h4>사용자 정보:</h4>
+                            <p><strong>ID:</strong> ${{data.id || 'N/A'}}</p>
+                            <p><strong>닉네임:</strong> ${{data.nickname || 'N/A'}}</p>
+                            <p><strong>프로필 이미지:</strong> ${{data.profileImage ? `<img src="${{data.profileImage}}" style="width: 30px; height: 30px; border-radius: 50%;">` : 'N/A'}}</p>
+                            <p><strong>신규 사용자:</strong> ${{data.isNew || 'N/A'}}</p>
+                            <p><strong>제공자:</strong> ${{data.provider?.type || 'N/A'}}</p>
+                        `;
+                        document.getElementById('userInfoFromToken').innerHTML = userInfoHtml;
+                        document.getElementById('codeTokenInfo').style.display = 'block';
+                    }} else {{
+                        const errorData = await response.json();
+                        alert('토큰 발급 실패: ' + (errorData.message || 'Unknown error'));
+                    }}
+                }} catch (error) {{
+                    alert('토큰 발급 중 오류 발생: ' + error.message);
+                }}
+            }}
+            
+            async function getTokenFromManualCode() {{
+                const code = document.getElementById('manualCodeInput').value.trim();
+                if (!code) {{
+                    alert('Auth code를 입력해주세요.');
+                    return;
+                }}
+                await getTokenFromCode(code);
             }}
         </script>
     </body>

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -203,19 +203,18 @@ async def home(request: Request):
         <p>아래 버튼을 클릭하여 카카오로 로그인하세요</p>
         
         <div style="margin: 20px 0;">
-            <h3>기존 방식 (토큰 직접 발급)</h3>
-            <form action="{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=http://localhost:{SERVICE_PORT}" method="post" style="display:inline;">
-                <button type="submit" class="login-btn">카카오로 로그인</button>
-            </form>
+            <h3>토큰 직접 발급 방식</h3>
+            <p style="margin-bottom: 15px; color: #666;">카카오 인증 후 바로 토큰을 발급받아 쿠키로 설정</p>
+            <button onclick="loginWithResponseType()" class="login-btn">카카오로 로그인 (토큰 방식)</button>
         </div>
         
         <div class="auth-flow-section">
-            <h3>새로운 방식 (Auth Code Flow)</h3>
+            <h3>Auth Code Flow 방식</h3>
             <p style="margin-bottom: 15px; color: #666;">1단계: Auth Code 받기 → 2단계: Code로 토큰 발급</p>
             <div style="margin: 15px 0;">
-                <button onclick="getAuthCode()" class="success-btn">1단계: Get Auth Code</button>
+                <button onclick="loginWithResponseType('code')" class="success-btn">1단계: Get Auth Code</button>
                 <p style="margin: 10px 0; font-size: 14px; color: #666;">
-                    ⚠️ 서버의 callback-mode가 'code'로 설정되어 있어야 합니다
+                    💡 responseType=code로 설정하면 auth code만 받습니다
                 </p>
             </div>
             <div style="margin: 15px 0;">
@@ -271,10 +270,15 @@ async def home(request: Request):
                 }}
             }}
             
-            function getAuthCode() {{
-                // Auth Code 플로우를 위해 새 창에서 카카오 로그인 시작
+            function loginWithResponseType(responseType) {{
+                // 선택한 responseType으로 카카오 로그인 시작
                 const redirectUri = encodeURIComponent('http://localhost:{SERVICE_PORT}');
-                const loginUrl = '{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=' + redirectUri;
+                let loginUrl = `{SERVER_URL}/api/v1/auth/kakao/login?redirectUri=${{redirectUri}}`;
+                
+                // responseType이 있는 경우에만 추가
+                if (responseType) {{
+                    loginUrl += `&responseType=${{responseType}}`;
+                }}
                 
                 // POST 요청을 위한 form 생성 및 제출
                 const form = document.createElement('form');

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -211,6 +211,16 @@ async def home(request: Request):
                 margin: 10px;
             }}
             .success-btn:hover {{ background-color: #218838; }}
+            .profile-section {{
+                margin-top: 30px;
+                padding: 20px;
+                background-color: #f0f8ff;
+                border-radius: 8px;
+                border-left: 4px solid #007bff;
+                max-width: 600px;
+                margin-left: auto;
+                margin-right: auto;
+            }}
         </style>
     </head>
     <body>
@@ -233,19 +243,6 @@ async def home(request: Request):
                 <div id="tokenInfo" class="token-info" style="display: none; margin-top: 15px;">
                     <h3>Access Token</h3>
                     <div id="tokenDisplay" class="token-display"></div>
-                    <div style="margin-top: 10px;">
-                        <button onclick="getMyProfile()" class="token-btn" style="margin-right: 10px;">Get My Profile (/me)</button>
-                        <input type="number" id="userIdInput" placeholder="사용자 ID 입력" class="token-input" style="width: 200px; margin-right: 10px;">
-                        <button onclick="getProfile()" class="token-btn">Get Profile (/{id})</button>
-                    </div>
-                    <div id="myProfileInfo" class="token-info" style="display: none; margin-top: 10px;">
-                        <h4>내 프로필 (/me)</h4>
-                        <div id="myProfileDisplay"></div>
-                    </div>
-                    <div id="profileInfo" class="token-info" style="display: none; margin-top: 10px;">
-                        <h4>사용자 프로필 (/{id})</h4>
-                        <div id="profileDisplay"></div>
-                    </div>
                 </div>
             </div>
         </div>
@@ -262,6 +259,29 @@ async def home(request: Request):
         </div>
         {user_info_section}
         {auth_code_section}
+        
+        <div class="profile-section">
+            <h3>프로필 조회 (공통)</h3>
+            <p style="margin-bottom: 15px; color: #666;">Access Token이 있으면 언제든지 프로필을 조회할 수 있습니다</p>
+            
+            <div class="token-section">
+                <div style="margin: 15px 0;">
+                    <button onclick="getMyProfile()" class="token-btn" style="margin-right: 10px;">Get My Profile (/me)</button>
+                    <input type="number" id="userIdInput" placeholder="사용자 ID 입력" class="token-input" style="width: 200px; margin-right: 10px;">
+                    <button onclick="getProfile()" class="token-btn">Get Profile (/{id})</button>
+                </div>
+                
+                <div id="myProfileInfo" class="token-info" style="display: none; margin-top: 15px;">
+                    <h4>내 프로필 (/me)</h4>
+                    <div id="myProfileDisplay"></div>
+                </div>
+                
+                <div id="profileInfo" class="token-info" style="display: none; margin-top: 15px;">
+                    <h4>사용자 프로필 (/{id})</h4>
+                    <div id="profileDisplay"></div>
+                </div>
+            </div>
+        </div>
         
         <script>
             async function getToken() {{
@@ -356,9 +376,28 @@ async def home(request: Request):
             
             async function getProfile() {{
                 try {{
-                    const accessToken = document.getElementById('tokenDisplay').textContent;
-                    if (!accessToken || accessToken === 'No token received') {{
-                        alert('먼저 Access Token을 가져와주세요.');
+                    // Token 방식의 Access Token 또는 Auth Code Flow의 Access Token 찾기
+                    let accessToken = null;
+                    
+                    // 1. Token 방식에서 발급받은 Access Token 확인
+                    const tokenDisplay = document.getElementById('tokenDisplay');
+                    if (tokenDisplay && tokenDisplay.textContent && tokenDisplay.textContent !== 'No token received') {{
+                        accessToken = tokenDisplay.textContent;
+                    }}
+                    
+                    // 2. Auth Code Flow에서 발급받은 Access Token 확인 (codeTokenDisplay에서 추출)
+                    if (!accessToken) {{
+                        const codeTokenDisplay = document.getElementById('codeTokenDisplay');
+                        if (codeTokenDisplay) {{
+                            const tokenMatch = codeTokenDisplay.innerHTML.match(/Access Token:<\/strong><\/p>[\s\S]*?<div[^>]*>([^<]+)<\/div>/);
+                            if (tokenMatch && tokenMatch[1] && tokenMatch[1] !== 'No access token') {{
+                                accessToken = tokenMatch[1].trim();
+                            }}
+                        }}
+                    }}
+                    
+                    if (!accessToken) {{
+                        alert('Access Token이 없습니다. 먼저 로그인하거나 토큰을 발급받아주세요.');
                         return;
                     }}
                     
@@ -385,8 +424,6 @@ async def home(request: Request):
                             <p><strong>이메일:</strong> ${{profileData.email}}</p>
                             <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
                             <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
-                            <p><strong>제공자:</strong> ${{profileData.provider?.type || 'N/A'}}</p>
-                            <p><strong>신규 사용자:</strong> ${{profileData.isNew ? 'Yes' : 'No'}}</p>
                         `;
                         document.getElementById('profileDisplay').innerHTML = profileHtml;
                         document.getElementById('profileInfo').style.display = 'block';
@@ -407,9 +444,28 @@ async def home(request: Request):
             
             async function getMyProfile() {{
                 try {{
-                    const accessToken = document.getElementById('tokenDisplay').textContent;
-                    if (!accessToken || accessToken === 'No token received') {{
-                        alert('먼저 Access Token을 가져와주세요.');
+                    // Token 방식의 Access Token 또는 Auth Code Flow의 Access Token 찾기
+                    let accessToken = null;
+                    
+                    // 1. Token 방식에서 발급받은 Access Token 확인
+                    const tokenDisplay = document.getElementById('tokenDisplay');
+                    if (tokenDisplay && tokenDisplay.textContent && tokenDisplay.textContent !== 'No token received') {{
+                        accessToken = tokenDisplay.textContent;
+                    }}
+                    
+                    // 2. Auth Code Flow에서 발급받은 Access Token 확인 (codeTokenDisplay에서 추출)
+                    if (!accessToken) {{
+                        const codeTokenDisplay = document.getElementById('codeTokenDisplay');
+                        if (codeTokenDisplay) {{
+                            const tokenMatch = codeTokenDisplay.innerHTML.match(/Access Token:<\/strong><\/p>[\s\S]*?<div[^>]*>([^<]+)<\/div>/);
+                            if (tokenMatch && tokenMatch[1] && tokenMatch[1] !== 'No access token') {{
+                                accessToken = tokenMatch[1].trim();
+                            }}
+                        }}
+                    }}
+                    
+                    if (!accessToken) {{
+                        alert('Access Token이 없습니다. 먼저 로그인하거나 토큰을 발급받아주세요.');
                         return;
                     }}
                     
@@ -430,8 +486,6 @@ async def home(request: Request):
                             <p><strong>이메일:</strong> ${{profileData.email}}</p>
                             <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
                             <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
-                            <p><strong>제공자:</strong> ${{profileData.provider?.type || 'N/A'}}</p>
-                            <p><strong>신규 사용자:</strong> ${{profileData.isNew ? 'Yes' : 'No'}}</p>
                         `;
                         document.getElementById('myProfileDisplay').innerHTML = profileHtml;
                         document.getElementById('myProfileInfo').style.display = 'block';

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -42,13 +42,22 @@ async def home(request: Request):
         <div class="user-info">
             <h2>로그인된 사용자</h2>
             <div class="user-details">
-                {f'<p><strong>ID:</strong> {user_id}</p>' if user_id else ''}
+                {f'<p><strong>🆔 사용자 ID:</strong> <span style="background-color: #007bff; color: white; padding: 2px 8px; border-radius: 4px; font-family: monospace;">{user_id}</span></p>' if user_id else ''}
                 {f'<p><strong>닉네임:</strong> {nickname}</p>' if nickname else ''}
                 {f'<p><strong>프로필 이미지:</strong> <img src="{profile_image}" alt="프로필" style="width: 50px; height: 50px; border-radius: 50%;"></p>' if profile_image else ''}
                 {f'<p><strong>신규 사용자:</strong> {is_new}</p>' if is_new else ''}
                 {f'<p><strong>제공자:</strong> {provider_type}</p>' if provider_type else ''}
             </div>
         </div>
+        <script>
+            // 페이지 로드 시 사용자 ID를 입력 필드에 자동으로 채움
+            document.addEventListener('DOMContentLoaded', function() {{
+                const userIdInput = document.getElementById('userIdInput');
+                if (userIdInput && '{user_id}') {{
+                    userIdInput.value = '{user_id}';
+                }}
+            }});
+        </script>
         """
     
     # auth code 섹션 HTML 생성
@@ -224,6 +233,14 @@ async def home(request: Request):
                 <div id="tokenInfo" class="token-info" style="display: none; margin-top: 15px;">
                     <h3>Access Token</h3>
                     <div id="tokenDisplay" class="token-display"></div>
+                    <div style="margin-top: 10px;">
+                        <input type="number" id="userIdInput" placeholder="사용자 ID 입력" class="token-input" style="width: 200px; margin-right: 10px;">
+                        <button onclick="getProfile()" class="token-btn">Get Profile</button>
+                    </div>
+                    <div id="profileInfo" class="token-info" style="display: none; margin-top: 10px;">
+                        <h4>사용자 프로필</h4>
+                        <div id="profileDisplay"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -329,6 +346,57 @@ async def home(request: Request):
                     }}
                 }} catch (error) {{
                     alert('토큰 발급 중 오류 발생: ' + error.message);
+                }}
+            }}
+            
+            async function getProfile() {{
+                try {{
+                    const accessToken = document.getElementById('tokenDisplay').textContent;
+                    if (!accessToken || accessToken === 'No token received') {{
+                        alert('먼저 Access Token을 가져와주세요.');
+                        return;
+                    }}
+                    
+                    const userId = document.getElementById('userIdInput').value;
+                    if (!userId) {{
+                        alert('사용자 ID를 입력해주세요.');
+                        return;
+                    }}
+                    
+                    const response = await fetch(`{SERVER_URL}/api/v1/users/${{userId}}`, {{
+                        method: 'GET',
+                        headers: {{
+                            'Authorization': `Bearer ${{accessToken}}`,
+                            'Content-Type': 'application/json',
+                        }}
+                    }});
+                    
+                    if (response.ok) {{
+                        const data = await response.json();
+                        const profileData = data.data; // SuccessResponse의 data 필드
+                        
+                        const profileHtml = `
+                            <p><strong>ID:</strong> ${{profileData.id}}</p>
+                            <p><strong>이메일:</strong> ${{profileData.email}}</p>
+                            <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
+                            <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
+                            <p><strong>제공자:</strong> ${{profileData.provider?.type || 'N/A'}}</p>
+                            <p><strong>신규 사용자:</strong> ${{profileData.isNew ? 'Yes' : 'No'}}</p>
+                        `;
+                        document.getElementById('profileDisplay').innerHTML = profileHtml;
+                        document.getElementById('profileInfo').style.display = 'block';
+                    }} else {{
+                        const errorData = await response.json();
+                        let errorMessage = 'Unknown error';
+                        if (response.status === 403) {{
+                            errorMessage = '권한이 없습니다. 본인의 ID만 조회할 수 있습니다.';
+                        }} else if (errorData.message) {{
+                            errorMessage = errorData.message;
+                        }}
+                        alert('프로필 조회 실패: ' + errorMessage);
+                    }}
+                }} catch (error) {{
+                    alert('프로필 조회 중 오류 발생: ' + error.message);
                 }}
             }}
             

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -234,11 +234,16 @@ async def home(request: Request):
                     <h3>Access Token</h3>
                     <div id="tokenDisplay" class="token-display"></div>
                     <div style="margin-top: 10px;">
+                        <button onclick="getMyProfile()" class="token-btn" style="margin-right: 10px;">Get My Profile (/me)</button>
                         <input type="number" id="userIdInput" placeholder="사용자 ID 입력" class="token-input" style="width: 200px; margin-right: 10px;">
-                        <button onclick="getProfile()" class="token-btn">Get Profile</button>
+                        <button onclick="getProfile()" class="token-btn">Get Profile (/{id})</button>
+                    </div>
+                    <div id="myProfileInfo" class="token-info" style="display: none; margin-top: 10px;">
+                        <h4>내 프로필 (/me)</h4>
+                        <div id="myProfileDisplay"></div>
                     </div>
                     <div id="profileInfo" class="token-info" style="display: none; margin-top: 10px;">
-                        <h4>사용자 프로필</h4>
+                        <h4>사용자 프로필 (/{id})</h4>
                         <div id="profileDisplay"></div>
                     </div>
                 </div>
@@ -397,6 +402,57 @@ async def home(request: Request):
                     }}
                 }} catch (error) {{
                     alert('프로필 조회 중 오류 발생: ' + error.message);
+                }}
+            }}
+            
+            async function getMyProfile() {{
+                try {{
+                    const accessToken = document.getElementById('tokenDisplay').textContent;
+                    if (!accessToken || accessToken === 'No token received') {{
+                        alert('먼저 Access Token을 가져와주세요.');
+                        return;
+                    }}
+                    
+                    const response = await fetch(`{SERVER_URL}/api/v1/users/me`, {{
+                        method: 'GET',
+                        headers: {{
+                            'Authorization': `Bearer ${{accessToken}}`,
+                            'Content-Type': 'application/json',
+                        }}
+                    }});
+                    
+                    if (response.ok) {{
+                        const data = await response.json();
+                        const profileData = data.data; // SuccessResponse의 data 필드
+                        
+                        const profileHtml = `
+                            <p><strong>ID:</strong> ${{profileData.id}}</p>
+                            <p><strong>이메일:</strong> ${{profileData.email}}</p>
+                            <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
+                            <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
+                            <p><strong>제공자:</strong> ${{profileData.provider?.type || 'N/A'}}</p>
+                            <p><strong>신규 사용자:</strong> ${{profileData.isNew ? 'Yes' : 'No'}}</p>
+                        `;
+                        document.getElementById('myProfileDisplay').innerHTML = profileHtml;
+                        document.getElementById('myProfileInfo').style.display = 'block';
+                        
+                        // 자동으로 사용자 ID 입력 필드에 채우기
+                        const userIdInput = document.getElementById('userIdInput');
+                        if (userIdInput && profileData.id) {{
+                            userIdInput.value = profileData.id;
+                        }}
+                    }} else {{
+                        const errorData = await response.json();
+                        let errorMessage = 'Unknown error';
+                        if (response.status === 401) {{
+                            errorMessage = '인증이 필요합니다. 유효한 Access Token을 사용해주세요.';
+                        }} else if (errorData.message) {{
+                            errorMessage = errorData.message;
+                        }}
+                        alert('내 프로필 조회 실패: ' + errorMessage);
+                    }}
+                }} catch (error) {{
+                    alert('내 프로필 조회 중 오류 발생: ' + error.message);
                 }}
             }}
             


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #75 

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->

- Auth code flow 방식을 optional하게 사용할 수 있게 됩니다. (기존 API에서 responseType 인자를 추가함)
- 자신의 user profile을 조회하는 API가 추가됩니다.
- userId를 통해 조회하는 user profile API가 추가됩니다.
- Python app "auth-test"에서 위 API들에 대한 테스트 케이스들이 추가됩니다. (Auth code flow, token 교환, profile 확인)

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

- Summary 참고

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

- 모바일 webView 환경 등 cookie 활용이 제한적인 케이스에 대응하기 위해 필요합니다.
- 실제 backend DB에 기록된 사용자 정보를 조회하기 위해 필요합니다.

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

- auth-test app을 통해 진행하였습니다.
- 기존의 token 방식 (set-cookie) + 해당 PR의 auth code flow 방식이 모두 잘 동작하는 것을 확인하였습니다.

(주의사항) 웹 브라우저에서 테스트하는 경우, set-cookie에 의해 refresh API가 동작하지 않을 수 있습니다. (cookie를 우선으로 확인함)
따라서, auth code flow를 테스트하는 경우, Incognito 모드에서 cookie 없이 request body에 "refreshToken"을 전달해야 합니다.

<img width="678" height="284" alt="image" src="https://github.com/user-attachments/assets/27aa0ebe-d2ba-4470-a8ca-66a8a56caf03" />

<img width="660" height="610" alt="image" src="https://github.com/user-attachments/assets/84607826-55cf-482d-9bdb-d345eafeb79e" />

<img width="659" height="592" alt="image" src="https://github.com/user-attachments/assets/f4544171-b87d-405e-a748-00ca62e791de" />

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

- 시퀀스 다이어그램을 준비 못했는데, 필요하시면 그려드리겠습니다! (오호 정확하진 않지만 코드래빗이 대충 그려줬네요. 코드래빗 최고!)

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인에 response_type 지원 및 코드 플로우 분리, 신규 토큰 교환 엔드포인트 추가(POST /api/v1/auth/kakao/token)
  - 로그인/콜백 리다이렉트 로직 개선 및 표준화된 에러 리다이렉트 메시지 강화
  - 사용자 API 추가: GET /api/v1/users/me, GET /api/v1/users/{id} (본인 확인 기반 프로필 조회)
  - 접근 거부(403) 에러 코드 도입으로 권한 검증 명확화
- 테스트
  - 데모 페이지에 Auth Code Flow, 토큰 교환, 프로필 조회(/me, /{id}) 시나리오 및 UI 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->