### PR TITLE
Feature/Update activity record

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/controller/ActivityRecordsController.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/controller/ActivityRecordsController.java
@@ -15,12 +15,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import depromeet.lessonfour.server.activityrecord.app.dto.request.CreateActivityRecordsRequest;
-import depromeet.lessonfour.server.activityrecord.app.dto.request.UpdateActivityRecordsRequest;
+import depromeet.lessonfour.server.activityrecord.api.dto.request.CreateActivityRecordsRequest;
+import depromeet.lessonfour.server.activityrecord.api.dto.request.UpdateActivityRecordsRequest;
 import depromeet.lessonfour.server.activityrecord.app.dto.response.GetActivityRecordsResponse;
 import depromeet.lessonfour.server.activityrecord.app.service.CreateActivityRecordUseCase;
 import depromeet.lessonfour.server.activityrecord.app.service.DeleteActivityRecordUseCase;
 import depromeet.lessonfour.server.activityrecord.app.service.QueryActivityRecordUseCase;
+import depromeet.lessonfour.server.activityrecord.app.service.UpdateActivityRecordUseCase;
 import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 public class ActivityRecordsController {
 
   private final CreateActivityRecordUseCase createActivityRecordUseCase;
+  private final UpdateActivityRecordUseCase updateActivityRecordUseCase;
   private final DeleteActivityRecordUseCase deleteActivityRecordUseCase;
   private final QueryActivityRecordUseCase queryActivityRecordUseCase;
 
@@ -48,7 +50,7 @@ public class ActivityRecordsController {
   public SuccessResponse<?> createActivityRecord(
       @AuthenticationPrincipal(expression = "id") Long userId,
       @RequestBody @Valid CreateActivityRecordsRequest dto) {
-    createActivityRecordUseCase.saveActivityRecord(userId, dto);
+    createActivityRecordUseCase.saveActivityRecord(userId, dto.to());
 
     return SuccessResponse.of(SuccessCode.SUCCESS_CREATE);
   }
@@ -59,8 +61,10 @@ public class ActivityRecordsController {
       security = {@SecurityRequirement(name = "JWT")})
   @PatchMapping("/{activityRecordId}")
   public SuccessResponse<?> updateActivityRecord(
+      @AuthenticationPrincipal(expression = "id") Long userId,
       @PathVariable("activityRecordId") Long activityRecordId,
       @RequestBody @Valid UpdateActivityRecordsRequest dto) {
+    updateActivityRecordUseCase.updateActivityRecord(userId, activityRecordId, dto.to());
     return SuccessResponse.of(SuccessCode.SUCCESS_UPDATE);
   }
 

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
@@ -1,10 +1,12 @@
-package depromeet.lessonfour.server.activityrecord.app.dto.request;
+package depromeet.lessonfour.server.activityrecord.api.dto.request;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto;
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto.FoodDto;
 import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
 import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
 import depromeet.lessonfour.server.common.annotation.ValidEnum;
@@ -24,4 +26,12 @@ public record CreateActivityRecordsRequest(
       @NotNull(message = "음식 id는 필수입니다") Long id,
       @NotNull(message = "식사 시간은 필수입니다") @ValidEnum(enumClass = MealTime.class, message = "유효하지 않은 식사시간입니다")
           MealTime mealTime) {}
+
+  public ActivityRecordDto to() {
+    List<FoodDto> foods = null;
+    if (this.foods != null) {
+      foods = this.foods.stream().map(fr -> new FoodDto(fr.id(), fr.mealTime())).toList();
+    }
+    return new ActivityRecordDto(foods, this.water, this.stress, this.occurredAt);
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
@@ -11,12 +11,12 @@ import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
 import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
 import depromeet.lessonfour.server.common.annotation.ValidEnum;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> foods,
-    @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") int water,
+    @PositiveOrZero(message = "마신 물의 잔 수는 0 이상이어야 합니다") int water,
     @NotNull(message = "스트레스 지수는 필수입니다") @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
         StressLevel stress,
     @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/UpdateActivityRecordsRequest.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 
 public record UpdateActivityRecordsRequest(
-    @Nullable @Valid List<UpdateFoodRequestDto> foods,
+    @Nullable @Valid List<@NotNull UpdateFoodRequestDto> foods,
     @Nullable @PositiveOrZero(message = "마신 물의 잔 수는 0 이상이어야 합니다") Integer water,
     @Nullable @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
         StressLevel stress) {

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/UpdateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/UpdateActivityRecordsRequest.java
@@ -1,27 +1,34 @@
-package depromeet.lessonfour.server.activityrecord.app.dto.request;
+package depromeet.lessonfour.server.activityrecord.api.dto.request;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto;
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto.FoodDto;
 import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
 import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
 import depromeet.lessonfour.server.common.annotation.ValidEnum;
 import jakarta.annotation.Nullable;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record UpdateActivityRecordsRequest(
     @Nullable @Valid List<UpdateFoodRequestDto> foods,
-    @Nullable @Min(value = 0, message = "마신 물의 잔 수는 양수여야 합니다") Integer water,
+    @Nullable @PositiveOrZero(message = "마신 물의 잔 수는 0 이상이어야 합니다") Integer water,
     @Nullable @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
-        StressLevel stress,
-    @Nullable @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS") LocalDateTime occurredAt) {
+        StressLevel stress) {
 
   public record UpdateFoodRequestDto(
       @NotNull(message = "음식 id는 필수입니다") Long id,
       @NotNull(message = "식사 시간은 필수입니다") @ValidEnum(enumClass = MealTime.class, message = "유효하지 않은 식사시간입니다.")
           MealTime mealTime) {}
+
+  public ActivityRecordDto to() {
+    List<FoodDto> foods = null;
+    if (this.foods != null) {
+      foods = this.foods.stream().map(fr -> new FoodDto(fr.id(), fr.mealTime())).toList();
+    }
+
+    return new ActivityRecordDto(foods, this.water, this.stress, null);
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/request/ActivityRecordDto.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/request/ActivityRecordDto.java
@@ -1,0 +1,13 @@
+package depromeet.lessonfour.server.activityrecord.app.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+
+public record ActivityRecordDto(
+    List<FoodDto> foods, Integer water, StressLevel stress, LocalDateTime occurredAt) {
+
+  public record FoodDto(Long id, MealTime mealTime) {}
+}

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/response/DailyExistenceResponse.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/dto/response/DailyExistenceResponse.java
@@ -1,5 +1,0 @@
-package depromeet.lessonfour.server.activityrecord.app.dto.response;
-
-import java.time.LocalDate;
-
-public record DailyExistenceResponse(LocalDate date, boolean exists) {}

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/service/CreateActivityRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/service/CreateActivityRecordUseCase.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 
-import depromeet.lessonfour.server.activityrecord.app.dto.request.CreateActivityRecordsRequest;
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto;
 import depromeet.lessonfour.server.activityrecord.app.support.MealFoodFactory;
 import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
 import depromeet.lessonfour.server.activityrecord.domain.repository.ActivityRecordRepository;
@@ -24,7 +24,7 @@ public class CreateActivityRecordUseCase {
   private final ActivityRecordRepository activityRecordRepository;
   private final MealFoodFactory mealFoodFactory;
 
-  public void saveActivityRecord(Long userId, CreateActivityRecordsRequest dto) {
+  public void saveActivityRecord(Long userId, ActivityRecordDto dto) {
     List<MealFood> mealFoods = mealFoodFactory.createMealFoods(dto.foods());
     ActivityRecord activityRecord =
         ActivityRecord.createWithMeals(

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/service/UpdateActivityRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/service/UpdateActivityRecordUseCase.java
@@ -1,0 +1,39 @@
+package depromeet.lessonfour.server.activityrecord.app.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto;
+import depromeet.lessonfour.server.activityrecord.app.support.MealFoodFactory;
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.repository.ActivityRecordRepository;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class UpdateActivityRecordUseCase {
+
+  private final ActivityRecordRepository activityRecordRepository;
+  private final MealFoodFactory mealFoodFactory;
+
+  public void updateActivityRecord(Long userId, Long activityRecordId, ActivityRecordDto dto) {
+    ActivityRecord activityRecord =
+        activityRecordRepository
+            .findById(activityRecordId)
+            .orElseThrow(() -> new ServerException(ErrorCode.DATA_NOT_FOUND));
+
+    if (!activityRecord.isOwnedBy(userId)) {
+      throw new ServerException(ErrorCode.ACCESS_DENIED);
+    }
+
+    List<MealFood> mealFoods = mealFoodFactory.createMealFoods(dto.foods());
+
+    activityRecord.update(dto.water(), dto.stress(), mealFoods);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/app/support/MealFoodFactory.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/app/support/MealFoodFactory.java
@@ -6,7 +6,7 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
-import depromeet.lessonfour.server.activityrecord.app.dto.request.CreateActivityRecordsRequest.CreateFoodRequestDto;
+import depromeet.lessonfour.server.activityrecord.app.dto.request.ActivityRecordDto.FoodDto;
 import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
 import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.exception.ServerException;
@@ -22,8 +22,11 @@ public class MealFoodFactory {
 
   private final FoodQueryService foodQueryService;
 
-  public List<MealFood> createMealFoods(List<CreateFoodRequestDto> dtos) {
-    if (dtos == null || dtos.isEmpty()) {
+  public List<MealFood> createMealFoods(List<FoodDto> dtos) {
+    if (dtos == null) {
+      return null;
+    }
+    if (dtos.isEmpty()) {
       return List.of();
     }
     Map<Long, Food> foodMap = getFoodMap(dtos);
@@ -40,8 +43,8 @@ public class MealFoodFactory {
         .toList();
   }
 
-  private Map<Long, Food> getFoodMap(List<CreateFoodRequestDto> dtos) {
-    List<Long> foodIds = dtos.stream().map(CreateFoodRequestDto::id).distinct().toList();
+  private Map<Long, Food> getFoodMap(List<FoodDto> dtos) {
+    List<Long> foodIds = dtos.stream().map(FoodDto::id).distinct().toList();
 
     return foodQueryService.findByIds(foodIds).stream()
         .collect(Collectors.toMap(Food::getId, food -> food, (a, b) -> a));

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/domain/entity/ActivityRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/domain/entity/ActivityRecord.java
@@ -88,11 +88,13 @@ public class ActivityRecord extends BaseTimeEntity {
             .activityAt(activityAt)
             .build();
 
-    mealFoods.stream()
-        .map(
-            mealFood ->
-                FoodRecord.createRecord(activityRecord, mealFood.food(), mealFood.mealTime()))
-        .forEach(activityRecord.foodRecords::add);
+    if (mealFoods != null) {
+      mealFoods.stream()
+          .map(
+              mealFood ->
+                  FoodRecord.createRecord(activityRecord, mealFood.food(), mealFood.mealTime()))
+          .forEach(activityRecord.foodRecords::add);
+    }
 
     return activityRecord;
   }
@@ -103,5 +105,16 @@ public class ActivityRecord extends BaseTimeEntity {
 
   public boolean isOwnedBy(Long userId) {
     return this.userId.equals(userId);
+  }
+
+  public void update(Integer water, StressLevel stress, List<MealFood> mealFoods) {
+    if (water != null) this.waterIntakeCups = water;
+    if (stress != null) this.stressLevel = stress;
+    if (mealFoods != null) {
+      this.foodRecords.clear();
+      mealFoods.stream()
+          .map(mealFood -> FoodRecord.createRecord(this, mealFood.food(), mealFood.mealTime()))
+          .forEach(this.foodRecords::add);
+    }
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/infra/repository/JpaActivityRecordRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/infra/repository/JpaActivityRecordRepository.java
@@ -14,6 +14,7 @@ public interface JpaActivityRecordRepository extends JpaRepository<ActivityRecor
 
   Optional<ActivityRecord> findByUserIdAndIdAndIsDeletedFalse(Long userId, Long activityRecordId);
 
+  /** test용 메서드 */
   @Query(
       "SELECT ar FROM ActivityRecord ar LEFT JOIN FETCH ar.foodRecords WHERE ar.id = :id AND ar.isDeleted = false")
   Optional<ActivityRecord> findByIdWithFoodRecords(@Param("id") Long id);

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/infra/repository/JpaActivityRecordRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/infra/repository/JpaActivityRecordRepository.java
@@ -3,6 +3,8 @@ package depromeet.lessonfour.server.activityrecord.infra.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
 
@@ -11,4 +13,8 @@ public interface JpaActivityRecordRepository extends JpaRepository<ActivityRecor
   Optional<ActivityRecord> findByIdAndIsDeletedFalse(Long activityRecordId);
 
   Optional<ActivityRecord> findByUserIdAndIdAndIsDeletedFalse(Long userId, Long activityRecordId);
+
+  @Query(
+      "SELECT ar FROM ActivityRecord ar LEFT JOIN FETCH ar.foodRecords WHERE ar.id = :id AND ar.isDeleted = false")
+  Optional<ActivityRecord> findByIdWithFoodRecords(@Param("id") Long id);
 }

--- a/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
@@ -47,7 +47,7 @@ public class User extends BaseTimeEntity {
 
   @Transient @Builder.Default private boolean isNew = false;
 
-  @Column @NotNull private boolean isDeleted = false;
+  @Column @NotNull @Builder.Default private boolean isDeleted = false;
 
   public static User register(
       String email, String nickname, String password, String profileImage, Provider provider) {

--- a/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
@@ -272,7 +272,7 @@ class CreateActivityRecordE2ETest {
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("마신 물의 잔 수는 양수여야 합니다"));
+        .body("message", containsString("요청 필드 값이 유효하지 않습니다.: water: 마신 물의 잔 수는 0 이상이어야 합니다"));
   }
 
   @Test

--- a/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/UpdateActivityRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/UpdateActivityRecordE2ETest.java
@@ -1,0 +1,657 @@
+package depromeet.lessonfour.server.activityrecord.controllers;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.food.domain.entity.Food;
+import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class UpdateActivityRecordE2ETest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private JwtTokenGenerator jwtTokenGenerator;
+  @Autowired private UserRepository jpaUserRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private FoodRepository foodRepository;
+  @Autowired private JpaActivityRecordRepository activityRecordRepository;
+
+  private String validJwtToken;
+  private User testUser;
+  private User otherUser;
+  private Long appleId;
+  private Long bananaId;
+  private Long saladId;
+  private Long burgerId;
+  private final DateTimeFormatter formatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    // 실제 사용자 생성 및 JWT 토큰 생성
+    testUser = createTestUser("test@example.com", "password123", "testuser");
+    otherUser = createTestUser("other@example.com", "password456", "otheruser");
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+
+    // Food 생성
+    List<Food> foods =
+        List.of(
+            Food.builder().name("사과").score(4.5).build(),
+            Food.builder().name("바나나").score(4.0).build(),
+            Food.builder().name("샐러드").score(5.0).build(),
+            Food.builder().name("햄버거").score(2.0).build());
+    List<Food> savedFoods = foodRepository.saveAll(foods);
+    appleId = savedFoods.get(0).getId();
+    bananaId = savedFoods.get(1).getId();
+    saladId = savedFoods.get(2).getId();
+    burgerId = savedFoods.get(3).getId();
+  }
+
+  private User createTestUser(String email, String password, String nickname) {
+    User user = User.register(email, nickname, passwordEncoder.encode(password));
+    return jpaUserRepository.save(user);
+  }
+
+  private ActivityRecord createTestActivityRecord(
+      User user, LocalDateTime occurredAt, int water, StressLevel stress) {
+    ActivityRecord record =
+        ActivityRecord.createWithMeals(
+            user.getId(),
+            water,
+            stress,
+            ActivityAt.from(occurredAt),
+            List.of(
+                new MealFood(MealTime.BREAKFAST, foodRepository.findById(appleId).orElseThrow())));
+    return activityRecordRepository.save(record);
+  }
+
+  @Test
+  @DisplayName("유효한 생활 기록 수정 요청시 성공적으로 수정된다")
+  void givenValidUpdateRequest_whenUpdateActivityRecord_thenSuccess() {
+    // given: 기존 생활 기록 생성
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 3, StressLevel.LOW);
+
+    String updateRequest =
+        String.format(
+            """
+        {
+          "foods": [
+            {
+              "id": %d,
+              "mealTime": "LUNCH"
+            },
+            {
+              "id": %d,
+              "mealTime": "DINNER"
+            }
+          ],
+          "water": 7,
+          "stress": "HIGH"
+        }
+        """,
+            bananaId, saladId);
+
+    // when & then
+    given()
+        .log()
+        .all()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200));
+
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getWaterIntakeCups()).isEqualTo(7);
+    assertThat(updatedRecord.getStressLevel()).isEqualTo(StressLevel.HIGH);
+    assertThat(updatedRecord.getFoodRecords()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("음식 목록만 수정 요청시 성공적으로 수정된다")
+  void givenOnlyFoodsUpdate_whenUpdateActivityRecord_thenSuccess() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        String.format(
+            """
+        {
+          "foods": [
+            {
+              "id": %d,
+              "mealTime": "SNACK"
+            }
+          ]
+        }
+        """,
+            burgerId);
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 음식은 변경, 물과 스트레스는 유지
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getWaterIntakeCups()).isEqualTo(5);
+    assertThat(updatedRecord.getStressLevel()).isEqualTo(StressLevel.MEDIUM);
+    assertThat(updatedRecord.getFoodRecords()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("물 섭취량만 수정 요청시 성공적으로 수정된다")
+  void givenOnlyWaterUpdate_whenUpdateActivityRecord_thenSuccess() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 3, StressLevel.LOW);
+
+    String updateRequest = """
+        {
+          "water": 9
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 물만 변경, 스트레스와 음식은 유지
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getWaterIntakeCups()).isEqualTo(9);
+    assertThat(updatedRecord.getStressLevel()).isEqualTo(StressLevel.LOW);
+    assertThat(updatedRecord.getFoodRecords()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("스트레스만 수정 요청시 성공적으로 수정된다")
+  void givenOnlyStressUpdate_whenUpdateActivityRecord_thenSuccess() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "stress": "VERY_HIGH"
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 스트레스만 변경, 물과 음식은 유지
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getWaterIntakeCups()).isEqualTo(5);
+    assertThat(updatedRecord.getStressLevel()).isEqualTo(StressLevel.VERY_HIGH);
+    assertThat(updatedRecord.getFoodRecords()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("음식 목록을 빈 배열로 수정하면 기존 음식이 모두 제거된다")
+  void givenEmptyFoodList_whenUpdateActivityRecord_thenAllFoodsRemoved() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "foods": []
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 음식 목록이 비어있어야 함
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getFoodRecords()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("JWT 토큰 없이 수정 요청시 401 에러를 반환한다")
+  void givenNoAuthToken_whenUpdateActivityRecord_thenUnauthorized() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "water": 7
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 JWT 토큰으로 수정 요청시 401 에러를 반환한다")
+  void givenInvalidAuthToken_whenUpdateActivityRecord_thenUnauthorized() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "water": 7
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer invalid-token")
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 생활 기록 수정 시도시 실패한다")
+  void givenOtherUserRecord_whenUpdateActivityRecord_thenForbidden() {
+    // given: 다른 사용자의 레코드 생성
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord otherUserRecord =
+        createTestActivityRecord(otherUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "water": 7
+        }
+        """;
+
+    // when & then: testUser의 토큰으로 otherUser의 레코드 수정 시도
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", otherUserRecord.getId())
+        .then()
+        .statusCode(HttpStatus.FORBIDDEN.value());
+  }
+
+  @Test
+  @DisplayName("물 섭취량이 음수인 경우 400 에러를 반환한다")
+  void givenNegativeWaterAmount_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "water": -1
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("message", containsString("마신 물의 잔 수는 0 이상이어야 합니다"));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 스트레스 지수인 경우 400 에러를 반환한다")
+  void givenInvalidStressLevel_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest = """
+        {
+          "stress": "INVALID_STRESS"
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("message", containsString("요청 본문이 올바르지 않습니다"));
+  }
+
+  @Test
+  @DisplayName("음식 ID가 null인 경우 400 에러를 반환한다")
+  void givenNullFoodId_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        """
+        {
+          "foods": [
+            {
+              "id": null,
+              "mealTime": "BREAKFAST"
+            }
+          ]
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("message", containsString("음식 id는 필수입니다"));
+  }
+
+  @Test
+  @DisplayName("식사 시간이 null인 경우 400 에러를 반환한다")
+  void givenNullMealTime_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        String.format(
+            """
+        {
+          "foods": [
+            {
+              "id": %d,
+              "mealTime": null
+            }
+          ]
+        }
+        """,
+            appleId);
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("message", containsString("식사 시간은 필수입니다"));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 식사 시간인 경우 400 에러를 반환한다")
+  void givenInvalidMealTime_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        String.format(
+            """
+        {
+          "foods": [
+            {
+              "id": %d,
+              "mealTime": "INVALID_MEAL_TIME"
+            }
+          ]
+        }
+        """,
+            appleId);
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("message", containsString("요청 본문이 올바르지 않습니다"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 생활 기록 ID로 수정 요청시 404 에러를 반환한다")
+  void givenNonExistentRecordId_whenUpdateActivityRecord_thenNotFound() {
+    // given
+    Long nonExistentId = 99999L;
+
+    String updateRequest = """
+        {
+          "water": 7
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", nonExistentId)
+        .then()
+        .statusCode(HttpStatus.NOT_FOUND.value());
+  }
+
+  @Test
+  @DisplayName("JSON 형식이 아닌 요청시 400 에러를 반환한다")
+  void givenNonJsonRequest_whenUpdateActivityRecord_thenBadRequest() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String invalidRequest = "not-json-format";
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(invalidRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("Content-Type이 application/json이 아닌 경우 415 에러를 반환한다")
+  void givenNonJsonContentType_whenUpdateActivityRecord_thenUnsupportedMediaType() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String requestBody = "water=7";
+
+    // when & then
+    given()
+        .contentType(ContentType.URLENC)
+        .header("Authorization", validJwtToken)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
+  }
+
+  @Test
+  @DisplayName("모든 필드를 null로 수정 요청시 기존 값이 유지된다")
+  void givenAllNullFields_whenUpdateActivityRecord_thenKeepOriginalValues() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        """
+        {
+          "foods": null,
+          "water": null,
+          "stress": null
+        }
+        """;
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 모든 값이 유지되어야 함
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getWaterIntakeCups()).isEqualTo(5);
+    assertThat(updatedRecord.getStressLevel()).isEqualTo(StressLevel.MEDIUM);
+    assertThat(updatedRecord.getFoodRecords()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("모든 식사 시간으로 음식 수정 요청시 성공한다")
+  void givenAllMealTimes_whenUpdateActivityRecord_thenSuccess() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+    ActivityRecord record = createTestActivityRecord(testUser, now, 5, StressLevel.MEDIUM);
+
+    String updateRequest =
+        String.format(
+            """
+        {
+          "foods": [
+            {
+              "id": %d,
+              "mealTime": "BREAKFAST"
+            },
+            {
+              "id": %d,
+              "mealTime": "LUNCH"
+            },
+            {
+              "id": %d,
+              "mealTime": "DINNER"
+            },
+            {
+              "id": %d,
+              "mealTime": "SNACK"
+            }
+          ]
+        }
+        """,
+            appleId, bananaId, saladId, burgerId);
+
+    // when & then
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(updateRequest)
+        .when()
+        .patch("/api/v1/activity-records/{activityRecordId}", record.getId())
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 4개의 음식이 모두 추가되었는지 확인
+    ActivityRecord updatedRecord =
+        activityRecordRepository.findByIdWithFoodRecords(record.getId()).orElseThrow();
+    assertThat(updatedRecord.getFoodRecords()).hasSize(4);
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* activity record update usecase 추가
* create usecase와 update usecase의 공통 로직 재사용을 위해 application dto 추가
* e2e test 추가
* 사용자 isDeleted Builder.Default 추가

## Changes ✨
* MealFoodFactory에서 create usecase와 update usecase에서 vo 생성을 재사용하기 위해 application dto 추가
* Update usecase 테스트를 위해 ActivityRecordRepository에 test용 메서드 추가
* npe 방지를 위해 ActivityRecord에 null check 추가
* 음식 목록을 받을 때 빈 배열을 받는 경우 모든 음식 목록 삭제, null인 경우 변경 X

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
e2e test 추가

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 활동 기록 수정 기능 추가(사용자 소유권 검증 포함) 및 입력 DTO 변환 통일
* **개선**
  * 음식 연관 데이터 조회 최적화로 업데이트 성능 향상 및 빈 배열로 음식 전체 제거 가능
  * 입력 검증 강화(음수 물 섭취 차단 등) 및 부분 업데이트(음식/물/스트레스) 지원
  * 기록 업데이트 시 널 안전성 및 빌더 기본값 보완
* **테스트**
  * 활동 기록 업데이트 통합 E2E 테스트 추가(성공·오류·경계 사례 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->