### PR TITLE
Feature/user profile management

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
@@ -1,0 +1,66 @@
+package depromeet.lessonfour.server.auth.infra.security.oauth.kakao;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoAdminClient {
+
+  private final RestTemplate restTemplate = new RestTemplate();
+  
+  @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
+  private String adminKey;
+  
+  @Value("${spring.security.oauth2.client.registration.kakao.unlink-uri}")
+  private String unlinkUri;
+
+  public void unlinkUser(String userId) {
+    log.debug("Unlinking Kakao user: {}", userId);
+    
+    try {
+      HttpHeaders headers = createHeaders();
+      MultiValueMap<String, String> requestBody = createRequestBody(userId);
+      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(requestBody, headers);
+
+      ResponseEntity<String> response = restTemplate.exchange(
+          unlinkUri, HttpMethod.POST, entity, String.class);
+
+      if (response.getStatusCode().is2xxSuccessful()) {
+        log.info("Kakao user unlink successful for user {}: {}", userId, response.getBody());
+      } else {
+        log.warn("Kakao user unlink failed for user {} with status: {}", 
+            userId, response.getStatusCode());
+      }
+    } catch (Exception e) {
+      log.error("Failed to unlink Kakao user {}", userId, e);
+      throw new RuntimeException("Kakao user unlink failed", e);
+    }
+  }
+
+  private HttpHeaders createHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "KakaoAK " + adminKey);
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    return headers;
+  }
+
+  private MultiValueMap<String, String> createRequestBody(String userId) {
+    MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+    requestBody.add("target_id_type", "user_id");
+    requestBody.add("target_id", userId);
+    return requestBody;
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
@@ -20,29 +20,31 @@ import lombok.extern.slf4j.Slf4j;
 public class KakaoAdminClient {
 
   private final RestTemplate restTemplate = new RestTemplate();
-  
+
   @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
   private String adminKey;
-  
+
   @Value("${spring.security.oauth2.client.registration.kakao.unlink-uri}")
   private String unlinkUri;
 
   public void unlinkUser(String userId) {
     log.debug("Unlinking Kakao user: {}", userId);
-    
+
     try {
       HttpHeaders headers = createHeaders();
       MultiValueMap<String, String> requestBody = createRequestBody(userId);
       HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(requestBody, headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
-          unlinkUri, HttpMethod.POST, entity, String.class);
+      ResponseEntity<String> response =
+          restTemplate.exchange(unlinkUri, HttpMethod.POST, entity, String.class);
 
       if (response.getStatusCode().is2xxSuccessful()) {
         log.info("Kakao user unlink successful for user {}: {}", userId, response.getBody());
       } else {
-        log.warn("Kakao user unlink failed for user {} with status: {}", 
-            userId, response.getStatusCode());
+        log.warn(
+            "Kakao user unlink failed for user {} with status: {}",
+            userId,
+            response.getStatusCode());
       }
     } catch (Exception e) {
       log.error("Failed to unlink Kakao user {}", userId, e);

--- a/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/infra/security/oauth/kakao/KakaoAdminClient.java
@@ -6,11 +6,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,13 +21,23 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class KakaoAdminClient {
 
-  private final RestTemplate restTemplate = new RestTemplate();
+  private RestTemplate restTemplate;
 
   @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
   private String adminKey;
 
   @Value("${spring.security.oauth2.client.registration.kakao.unlink-uri}")
   private String unlinkUri;
+
+  @PostConstruct
+  public void initRestTemplate() {
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(15000); // 15초 연결 타임아웃
+    factory.setReadTimeout(15000); // 15초 읽기 타임아웃
+
+    this.restTemplate = new RestTemplate(factory);
+    log.debug("RestTemplate initialized with 30 second timeout");
+  }
 
   public void unlinkUser(String userId) {
     log.debug("Unlinking Kakao user: {}", userId);

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -89,10 +89,11 @@ public class UserController {
 
   @Operation(
       summary = "회원 탈퇴",
-      description = "현재 로그인한 사용자의 계정을 삭제합니다.",
+      description = "현재 로그인한 사용자의 계정을 삭제합니다. Kakao 사용자의 경우 Kakao 연동도 해제됩니다.",
       security = {@SecurityRequirement(name = "JWT")})
   @DeleteMapping("/me")
   public SuccessResponse<Void> delete(@AuthenticationPrincipal(expression = "id") Long userId) {
+
     userDeleteUseCase.delete(userId);
 
     return SuccessResponse.of(SuccessCode.SUCCESS_DELETE);

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -1,10 +1,13 @@
 package depromeet.lessonfour.server.user.api.controller;
 
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,12 +15,16 @@ import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.user.app.dto.request.UpdateUserProfileRequestDto;
+import depromeet.lessonfour.server.user.app.dto.response.UpdateUserProfileResponseDto;
 import depromeet.lessonfour.server.user.app.dto.response.UserProfileResponseDto;
 import depromeet.lessonfour.server.user.app.service.UserDeleteUseCase;
 import depromeet.lessonfour.server.user.app.service.UserQueryService;
+import depromeet.lessonfour.server.user.app.service.UserUpdateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "사용자", description = "사용자 관련 API 문서입니다.")
@@ -27,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
   private final UserQueryService userQueryService;
+  private final UserUpdateService userUpdateService;
   private final UserDeleteUseCase userDeleteUseCase;
 
   @Operation(
@@ -59,6 +67,24 @@ public class UserController {
     UserProfileResponseDto user =
         UserProfileResponseDto.of(userQueryService.getActivatedUserById(userId));
     return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_FETCH, user));
+  }
+
+  @Operation(
+      summary = "내 프로필 수정",
+      description = "현재 로그인한 사용자의 프로필 정보를 수정합니다. 일부 필드만 수정 가능합니다.",
+      security = {@SecurityRequirement(name = "JWT")})
+  @PatchMapping(
+      value = "/me",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<SuccessResponse<UpdateUserProfileResponseDto>> updateMyProfile(
+      @Valid @RequestBody UpdateUserProfileRequestDto requestDto,
+      @AuthenticationPrincipal(expression = "id") Long authenticatedUserId) {
+
+    var updatedUser = userUpdateService.updateUserProfile(authenticatedUserId, requestDto);
+    UpdateUserProfileResponseDto response = UpdateUserProfileResponseDto.of(updatedUser);
+
+    return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SUCCESS_UPDATE, response));
   }
 
   @Operation(

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/request/UpdateUserProfileRequestDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/request/UpdateUserProfileRequestDto.java
@@ -1,0 +1,19 @@
+package depromeet.lessonfour.server.user.app.dto.request;
+
+import depromeet.lessonfour.server.user.domain.vo.Gender;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+
+@Builder
+public record UpdateUserProfileRequestDto(
+    @Size(max = 32, message = "닉네임은 32자를 초과할 수 없습니다")
+    String nickname,
+    
+    @Size(max = 512, message = "프로필 이미지 URL은 512자를 초과할 수 없습니다")
+    String profileImage,
+    
+    Gender gender,
+    
+    Integer birthYear
+) {
+}

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/request/UpdateUserProfileRequestDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/request/UpdateUserProfileRequestDto.java
@@ -1,19 +1,13 @@
 package depromeet.lessonfour.server.user.app.dto.request;
 
+import depromeet.lessonfour.server.user.app.validator.ValidBirthYear;
 import depromeet.lessonfour.server.user.domain.vo.Gender;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 @Builder
 public record UpdateUserProfileRequestDto(
-    @Size(max = 32, message = "닉네임은 32자를 초과할 수 없습니다")
-    String nickname,
-    
-    @Size(max = 512, message = "프로필 이미지 URL은 512자를 초과할 수 없습니다")
-    String profileImage,
-    
+    @Size(max = 32, message = "닉네임은 32자를 초과할 수 없습니다") String nickname,
+    @Size(max = 512, message = "프로필 이미지 URL은 512자를 초과할 수 없습니다") String profileImage,
     Gender gender,
-    
-    Integer birthYear
-) {
-}
+    @ValidBirthYear Integer birthYear) {}

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UpdateUserProfileResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UpdateUserProfileResponseDto.java
@@ -1,0 +1,24 @@
+package depromeet.lessonfour.server.user.app.dto.response;
+
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.vo.Gender;
+
+public record UpdateUserProfileResponseDto(
+    Long id,
+    String email,
+    String nickname,
+    String profileImage,
+    Gender gender,
+    Integer birthYear
+) {
+    public static UpdateUserProfileResponseDto of(User user) {
+        return new UpdateUserProfileResponseDto(
+            user.getId(),
+            user.getEmail(),
+            user.getNickname(),
+            user.getProfileImage(),
+            user.getGender(),
+            user.getBirthYear()
+        );
+    }
+}

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UpdateUserProfileResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UpdateUserProfileResponseDto.java
@@ -4,21 +4,14 @@ import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.domain.vo.Gender;
 
 public record UpdateUserProfileResponseDto(
-    Long id,
-    String email,
-    String nickname,
-    String profileImage,
-    Gender gender,
-    Integer birthYear
-) {
-    public static UpdateUserProfileResponseDto of(User user) {
-        return new UpdateUserProfileResponseDto(
-            user.getId(),
-            user.getEmail(),
-            user.getNickname(),
-            user.getProfileImage(),
-            user.getGender(),
-            user.getBirthYear()
-        );
-    }
+    Long id, String email, String nickname, String profileImage, Gender gender, Integer birthYear) {
+  public static UpdateUserProfileResponseDto of(User user) {
+    return new UpdateUserProfileResponseDto(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getProfileImage(),
+        user.getGender(),
+        user.getBirthYear());
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/dto/response/UserProfileResponseDto.java
@@ -1,11 +1,26 @@
 package depromeet.lessonfour.server.user.app.dto.response;
 
 import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.vo.Gender;
+import depromeet.lessonfour.server.user.domain.vo.Provider;
 
-public record UserProfileResponseDto(Long id, String email, String nickname, String profileImage) {
+public record UserProfileResponseDto(
+    Long id,
+    String email,
+    String nickname,
+    String profileImage,
+    Provider provider,
+    Gender gender,
+    Integer birthYear) {
 
   public static UserProfileResponseDto of(User user) {
     return new UserProfileResponseDto(
-        user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage());
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getProfileImage(),
+        user.getProvider(),
+        user.getGender(),
+        user.getBirthYear());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserDeleteUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserDeleteUseCase.java
@@ -1,16 +1,8 @@
 package depromeet.lessonfour.server.user.app.service;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 
+import depromeet.lessonfour.server.auth.infra.security.oauth.kakao.KakaoAdminClient;
 import depromeet.lessonfour.server.common.annotation.UseCase;
 import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.exception.ServerException;
@@ -22,19 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @UseCase
-@Transactional
 @RequiredArgsConstructor
 public class UserDeleteUseCase {
 
   private final UserRepository userRepository;
-  private final RestTemplate restTemplate = new RestTemplate();
-  
-  @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
-  private String kakaoAdminKey;
-  
-  @Value("${spring.security.oauth2.client.registration.kakao.unlink-uri}")
-  private String kakaoUnlinkUri;
+  private final KakaoAdminClient kakaoAdminClient;
 
+  @Transactional
   public void delete(Long userId) {
     User user =
         userRepository
@@ -47,7 +33,12 @@ public class UserDeleteUseCase {
 
     // Kakao 사용자인 경우 Kakao API 호출
     if (user.getProvider() != null && user.getProvider().getType() == Provider.ProviderType.KAKAO) {
-      unlinkKakaoUser(user.getProvider().getId());
+      try {
+        kakaoAdminClient.unlinkUser(user.getProvider().getId());
+      } catch (Exception e) {
+        log.error("Failed to unlink Kakao user {}", user.getProvider().getId(), e);
+        // Kakao 연동 실패해도 DB 삭제는 진행 (사용자 요청이므로)
+      }
     }
 
     // DB에서 사용자 비활성화 및 refresh token 제거
@@ -55,36 +46,5 @@ public class UserDeleteUseCase {
     user.storeRefreshToken(null);
 
     log.info("User {} has been successfully deleted", userId);
-  }
-
-  private void unlinkKakaoUser(String kakaoUserId) {
-    log.debug("kakaoUserId = " + kakaoUserId);
-    try {
-      HttpHeaders headers = new HttpHeaders();
-      headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
-      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-      MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
-      requestBody.add("target_id_type", "user_id");
-      requestBody.add("target_id", kakaoUserId);
-      
-      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(requestBody, headers);
-
-      ResponseEntity<String> response =
-          restTemplate.exchange(kakaoUnlinkUri, HttpMethod.POST, entity, String.class);
-
-      if (response.getStatusCode().is2xxSuccessful()) {
-        log.info("Kakao user unlink successful for user {}: {}", kakaoUserId, response.getBody());
-        
-      } else {
-        log.warn(
-            "Kakao user unlink failed for user {} with status: {}",
-            kakaoUserId,
-            response.getStatusCode());
-      }
-    } catch (Exception e) {
-      log.error("Failed to unlink Kakao user {}", kakaoUserId, e);
-      // Kakao 연동 실패해도 DB 삭제는 진행 (사용자 요청이므로)
-    }
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserDeleteUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserDeleteUseCase.java
@@ -1,29 +1,90 @@
 package depromeet.lessonfour.server.user.app.service;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 import depromeet.lessonfour.server.common.annotation.UseCase;
 import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import depromeet.lessonfour.server.user.domain.vo.Provider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @UseCase
 @Transactional
 @RequiredArgsConstructor
 public class UserDeleteUseCase {
 
   private final UserRepository userRepository;
+  private final RestTemplate restTemplate = new RestTemplate();
+  
+  @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
+  private String kakaoAdminKey;
+  
+  @Value("${spring.security.oauth2.client.registration.kakao.unlink-uri}")
+  private String kakaoUnlinkUri;
 
   public void delete(Long userId) {
     User user =
         userRepository
             .findById(userId)
             .orElseThrow(() -> new ServerException(ErrorCode.USER_NOT_FOUND));
+
     if (user.isDeleted()) {
       return;
     }
+
+    // Kakao 사용자인 경우 Kakao API 호출
+    if (user.getProvider() != null && user.getProvider().getType() == Provider.ProviderType.KAKAO) {
+      unlinkKakaoUser(user.getProvider().getId());
+    }
+
+    // DB에서 사용자 비활성화 및 refresh token 제거
     user.deactivate();
+    user.storeRefreshToken(null);
+
+    log.info("User {} has been successfully deleted", userId);
+  }
+
+  private void unlinkKakaoUser(String kakaoUserId) {
+    log.debug("kakaoUserId = " + kakaoUserId);
+    try {
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Authorization", "KakaoAK " + kakaoAdminKey);
+      headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+      MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+      requestBody.add("target_id_type", "user_id");
+      requestBody.add("target_id", kakaoUserId);
+      
+      HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(requestBody, headers);
+
+      ResponseEntity<String> response =
+          restTemplate.exchange(kakaoUnlinkUri, HttpMethod.POST, entity, String.class);
+
+      if (response.getStatusCode().is2xxSuccessful()) {
+        log.info("Kakao user unlink successful for user {}: {}", kakaoUserId, response.getBody());
+        
+      } else {
+        log.warn(
+            "Kakao user unlink failed for user {} with status: {}",
+            kakaoUserId,
+            response.getStatusCode());
+      }
+    } catch (Exception e) {
+      log.error("Failed to unlink Kakao user {}", kakaoUserId, e);
+      // Kakao 연동 실패해도 DB 삭제는 진행 (사용자 요청이므로)
+    }
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
@@ -26,7 +26,6 @@ public class UserService {
                 });
     if (user.isDeleted()) {
       user.activate();
-      userRepository.save(user);
     }
     return user;
   }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
@@ -16,12 +16,17 @@ public class UserService {
 
   @Transactional
   public User findOrCreate(String email, String nickname, String profileImage, Provider provider) {
-    return userRepository
+    User user = userRepository
         .findByEmail(email)
         .orElseGet(
             () -> {
               User newUser = User.register(email, nickname, null, profileImage, provider);
               return userRepository.save(newUser);
             });
+    if (user.isDeleted()) {
+      user.activate();
+      userRepository.save(user);
+    }
+    return user;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserService.java
@@ -16,13 +16,14 @@ public class UserService {
 
   @Transactional
   public User findOrCreate(String email, String nickname, String profileImage, Provider provider) {
-    User user = userRepository
-        .findByEmail(email)
-        .orElseGet(
-            () -> {
-              User newUser = User.register(email, nickname, null, profileImage, provider);
-              return userRepository.save(newUser);
-            });
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseGet(
+                () -> {
+                  User newUser = User.register(email, nickname, null, profileImage, provider);
+                  return userRepository.save(newUser);
+                });
     if (user.isDeleted()) {
       user.activate();
       userRepository.save(user);

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserUpdateService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserUpdateService.java
@@ -3,6 +3,10 @@ package depromeet.lessonfour.server.user.app.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.user.app.dto.request.UpdateUserProfileRequestDto;
+import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -20,5 +24,19 @@ public class UserUpdateService {
             user -> {
               user.storeRefreshToken(newRefreshToken);
             });
+  }
+
+  public User updateUserProfile(Long userId, UpdateUserProfileRequestDto requestDto) {
+    User user = userRepository
+        .findActiveById(userId)
+        .orElseThrow(() -> new ServerException(ErrorCode.USER_NOT_FOUND));
+    
+    user.updateProfile(
+        requestDto.nickname(),
+        requestDto.profileImage(),
+        requestDto.gender(),
+        requestDto.birthYear()
+    );
+    return user;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/service/UserUpdateService.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/service/UserUpdateService.java
@@ -27,16 +27,16 @@ public class UserUpdateService {
   }
 
   public User updateUserProfile(Long userId, UpdateUserProfileRequestDto requestDto) {
-    User user = userRepository
-        .findActiveById(userId)
-        .orElseThrow(() -> new ServerException(ErrorCode.USER_NOT_FOUND));
-    
+    User user =
+        userRepository
+            .findActiveById(userId)
+            .orElseThrow(() -> new ServerException(ErrorCode.USER_NOT_FOUND));
+
     user.updateProfile(
         requestDto.nickname(),
         requestDto.profileImage(),
         requestDto.gender(),
-        requestDto.birthYear()
-    );
+        requestDto.birthYear());
     return user;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/validator/BirthYearValidator.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/validator/BirthYearValidator.java
@@ -1,0 +1,21 @@
+package depromeet.lessonfour.server.user.app.validator;
+
+import java.time.LocalDate;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class BirthYearValidator implements ConstraintValidator<ValidBirthYear, Integer> {
+
+  private static final int MIN_BIRTH_YEAR = 1900;
+
+  @Override
+  public boolean isValid(Integer birthYear, ConstraintValidatorContext context) {
+    if (birthYear == null) {
+      return true; // null 값은 허용 (선택적 필드)
+    }
+
+    int currentYear = LocalDate.now().getYear();
+    return birthYear > MIN_BIRTH_YEAR && birthYear <= currentYear;
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/user/app/validator/BirthYearValidator.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/validator/BirthYearValidator.java
@@ -16,6 +16,6 @@ public class BirthYearValidator implements ConstraintValidator<ValidBirthYear, I
     }
 
     int currentYear = LocalDate.now().getYear();
-    return birthYear > MIN_BIRTH_YEAR && birthYear <= currentYear;
+    return birthYear >= MIN_BIRTH_YEAR && birthYear <= currentYear;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/app/validator/ValidBirthYear.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/validator/ValidBirthYear.java
@@ -1,0 +1,22 @@
+package depromeet.lessonfour.server.user.app.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = BirthYearValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidBirthYear {
+  String message() default "출생연도는 1900년보다 크고 현재 연도보다 작거나 같아야 합니다";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/depromeet/lessonfour/server/user/app/validator/ValidBirthYear.java
+++ b/src/main/java/depromeet/lessonfour/server/user/app/validator/ValidBirthYear.java
@@ -14,7 +14,7 @@ import jakarta.validation.Payload;
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidBirthYear {
-  String message() default "출생연도는 1900년보다 크고 현재 연도보다 작거나 같아야 합니다";
+  String message() default "출생연도는 1900년 이상 현재 연도 이하여야 합니다";
 
   Class<?>[] groups() default {};
 

--- a/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
@@ -1,10 +1,13 @@
 package depromeet.lessonfour.server.user.domain.entity;
 
 import depromeet.lessonfour.server.common.domain.entity.BaseTimeEntity;
+import depromeet.lessonfour.server.user.domain.vo.Gender;
 import depromeet.lessonfour.server.user.domain.vo.Provider;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -45,6 +48,12 @@ public class User extends BaseTimeEntity {
   @Column(length = 512)
   private String refreshToken;
 
+  @Column(length = 1)
+  @Enumerated(EnumType.STRING)
+  private Gender gender;
+
+  @Column private Integer birthYear;
+
   @Transient @Builder.Default private boolean isNew = false;
 
   @Column @NotNull private boolean isDeleted = false;
@@ -70,6 +79,39 @@ public class User extends BaseTimeEntity {
 
   public static User register(String email, String nickname, String password, String profileImage) {
     return register(email, nickname, password, profileImage, null);
+  }
+
+  public static User register(
+      String email,
+      String nickname,
+      String password,
+      String profileImage,
+      Gender gender,
+      Integer birthYear) {
+    return register(email, nickname, password, profileImage, null, gender, birthYear);
+  }
+
+  public static User register(
+      String email,
+      String nickname,
+      String password,
+      String profileImage,
+      Provider provider,
+      Gender gender,
+      Integer birthYear) {
+    if (provider == null) {
+      provider = Provider.local();
+    }
+    return User.builder()
+        .email(email)
+        .nickname(nickname)
+        .password(password)
+        .profileImage(profileImage)
+        .provider(provider)
+        .gender(gender)
+        .birthYear(birthYear)
+        .isNew(true)
+        .build();
   }
 
   public void storeRefreshToken(String refreshToken) {

--- a/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
@@ -122,7 +122,8 @@ public class User extends BaseTimeEntity {
     this.isDeleted = true;
   }
 
-  public void updateProfile(String nickname, String profileImage, Gender gender, Integer birthYear) {
+  public void updateProfile(
+      String nickname, String profileImage, Gender gender, Integer birthYear) {
     if (nickname != null && !nickname.isBlank()) {
       this.nickname = nickname;
     }

--- a/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
@@ -121,4 +121,19 @@ public class User extends BaseTimeEntity {
   public void deactivate() {
     this.isDeleted = true;
   }
+
+  public void updateProfile(String nickname, String profileImage, Gender gender, Integer birthYear) {
+    if (nickname != null && !nickname.isBlank()) {
+      this.nickname = nickname;
+    }
+    if (profileImage != null) {
+      this.profileImage = profileImage;
+    }
+    if (gender != null) {
+      this.gender = gender;
+    }
+    if (birthYear != null) {
+      this.birthYear = birthYear;
+    }
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/entity/User.java
@@ -122,6 +122,10 @@ public class User extends BaseTimeEntity {
     this.isDeleted = true;
   }
 
+  public void activate() {
+    this.isDeleted = false;
+  }
+
   public void updateProfile(
       String nickname, String profileImage, Gender gender, Integer birthYear) {
     if (nickname != null && !nickname.isBlank()) {

--- a/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Gender {
-  MALE("M"),
-  FEMALE("F");
+  M("M"),
+  F("F");
 
   private final String value;
 

--- a/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
@@ -1,5 +1,8 @@
 package depromeet.lessonfour.server.user.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +14,12 @@ public enum Gender {
 
   private final String value;
 
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @JsonCreator
   public static Gender from(String value) {
     if (value == null) {
       return null;
@@ -20,6 +29,6 @@ public enum Gender {
         return gender;
       }
     }
-    throw new IllegalArgumentException("Invalid gender value: " + value);
+    throw new IllegalArgumentException("성별은 \"M\" 또는 \"F\" 중 하나여야 합니다. 입력된 값: " + value);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
+++ b/src/main/java/depromeet/lessonfour/server/user/domain/vo/Gender.java
@@ -1,0 +1,25 @@
+package depromeet.lessonfour.server.user.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+  MALE("M"),
+  FEMALE("F");
+
+  private final String value;
+
+  public static Gender from(String value) {
+    if (value == null) {
+      return null;
+    }
+    for (Gender gender : Gender.values()) {
+      if (gender.value.equals(value)) {
+        return gender;
+      }
+    }
+    throw new IllegalArgumentException("Invalid gender value: " + value);
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,8 @@ spring:
             client-id: ${KAKAO__CLIENT_ID:your-kakao-client-id}
             client-secret: ${KAKAO__CLIENT_SECRET:your-kakao-client-secret}
             redirect-uri: ${KAKAO__REDIRECT_URL:http://localhost:8080/api/v1/auth/kakao/callback}
+            admin-key: ${KAKAO__ADMIN_KEY:your-kakao-admin-key}
+            unlink-uri: https://kapi.kakao.com/v1/user/unlink
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
             client-name: Kakao

--- a/src/main/resources/db/migration/V19__add_gender_and_birth_year_to_users.sql
+++ b/src/main/resources/db/migration/V19__add_gender_and_birth_year_to_users.sql
@@ -1,0 +1,3 @@
+-- Add gender and birth_year columns to users table
+ALTER TABLE users ADD COLUMN gender VARCHAR(1);
+ALTER TABLE users ADD COLUMN birth_year INTEGER;

--- a/src/test/java/depromeet/lessonfour/server/user/api/controller/ProfileUpdateE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/user/api/controller/ProfileUpdateE2ETest.java
@@ -1,0 +1,419 @@
+package depromeet.lessonfour.server.user.api.controller;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import depromeet.lessonfour.server.user.domain.vo.Gender;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class ProfileUpdateE2ETest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private JwtTokenGenerator jwtTokenGenerator;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  private String validJwtToken;
+  private User testUser;
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    // 테스트용 사용자 생성
+    testUser = createTestUser("test@example.com", "password123", "testuser");
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+  }
+
+  private User createTestUser(String email, String password, String nickname) {
+    User user = User.register(email, nickname, passwordEncoder.encode(password));
+    return userRepository.save(user);
+  }
+
+  @Test
+  @DisplayName("유효한 프로필 업데이트 요청시 성공적으로 업데이트된다")
+  void givenValidProfileUpdateRequest_whenUpdateProfile_thenSuccess() {
+    String requestBody =
+        """
+        {
+          "nickname": "updateduser",
+          "profileImage": "https://example.com/new-profile.jpg",
+          "gender": "M",
+          "birthYear": 1990
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.nickname", equalTo("updateduser"))
+        .body("data.profileImage", equalTo("https://example.com/new-profile.jpg"))
+        .body("data.gender", equalTo("M"))
+        .body("data.birthYear", equalTo(1990));
+  }
+
+  @Test
+  @DisplayName("JWT 토큰 없이 프로필 업데이트 요청시 401 에러를 반환한다")
+  void givenNoAuthToken_whenUpdateProfile_thenUnauthorized() {
+    String requestBody = """
+        {
+          "nickname": "updateduser"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 JWT 토큰으로 프로필 업데이트 요청시 401 에러를 반환한다")
+  void givenInvalidAuthToken_whenUpdateProfile_thenUnauthorized() {
+    String requestBody = """
+        {
+          "nickname": "updateduser"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", "Bearer invalid-token")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("닉네임만 업데이트할 수 있다")
+  void givenOnlyNickname_whenUpdateProfile_thenSuccess() {
+    String requestBody = """
+        {
+          "nickname": "newnickname"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.nickname", equalTo("newnickname"));
+  }
+
+  @Test
+  @DisplayName("프로필 이미지만 업데이트할 수 있다")
+  void givenOnlyProfileImage_whenUpdateProfile_thenSuccess() {
+    String requestBody =
+        """
+        {
+          "profileImage": "https://example.com/profile.jpg"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.profileImage", equalTo("https://example.com/profile.jpg"));
+  }
+
+  @Test
+  @DisplayName("성별만 업데이트할 수 있다")
+  void givenOnlyGender_whenUpdateProfile_thenSuccess() {
+    String requestBody = """
+        {
+          "gender": "F"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.gender", equalTo("F"));
+  }
+
+  @Test
+  @DisplayName("출생년도만 업데이트할 수 있다")
+  void givenOnlyBirthYear_whenUpdateProfile_thenSuccess() {
+    String requestBody = """
+        {
+          "birthYear": 1985
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.birthYear", equalTo(1985));
+  }
+
+  @Test
+  @DisplayName("닉네임이 32자를 초과하면 400 에러를 반환한다")
+  void givenNicknameTooLong_whenUpdateProfile_thenBadRequest() {
+    String longNickname = "a".repeat(33);
+    String requestBody =
+        String.format(
+            """
+            {
+              "nickname": "%s"
+            }
+            """,
+            longNickname);
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("프로필 이미지 URL이 512자를 초과하면 400 에러를 반환한다")
+  void givenProfileImageUrlTooLong_whenUpdateProfile_thenBadRequest() {
+    String longUrl = "https://example.com/" + "a".repeat(500);
+    String requestBody =
+        String.format(
+            """
+            {
+              "profileImage": "%s"
+            }
+            """,
+            longUrl);
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("잘못된 성별 값으로 요청시 400 에러를 반환한다")
+  void givenInvalidGender_whenUpdateProfile_thenBadRequest() {
+    String requestBody = """
+        {
+          "gender": "INVALID"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("잘못된 출생년도로 요청시 400 에러를 반환한다")
+  void givenInvalidBirthYear_whenUpdateProfile_thenBadRequest() {
+    String requestBody = """
+        {
+          "birthYear": 1800
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("빈 요청 본문으로 요청시 성공한다")
+  void givenEmptyRequestBody_whenUpdateProfile_thenSuccess() {
+    String requestBody = "{}";
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200));
+  }
+
+  @Test
+  @DisplayName("프로필 업데이트 후 데이터베이스에서 변경사항이 반영된다")
+  void givenSuccessfulUpdate_whenCheckDatabase_thenUpdated() {
+    String requestBody =
+        """
+        {
+          "nickname": "updateduser",
+          "gender": "F",
+          "birthYear": 1995
+        }
+        """;
+
+    // 프로필 업데이트 요청
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 데이터베이스에서 변경사항 확인
+    User updatedUser =
+        userRepository
+            .findById(testUser.getId())
+            .orElseThrow(() -> new RuntimeException("User should exist in database"));
+
+    assertThat(updatedUser.getNickname()).isEqualTo("updateduser");
+    assertThat(updatedUser.getGender()).isEqualTo(Gender.F);
+    assertThat(updatedUser.getBirthYear()).isEqualTo(1995);
+  }
+
+  @Test
+  @DisplayName("잘못된 Bearer 토큰 형식으로 요청시 401 에러를 반환한다")
+  void givenInvalidBearerFormat_whenUpdateProfile_thenUnauthorized() {
+    String tokenWithoutBearer = validJwtToken.replace("Bearer ", "");
+    String requestBody = """
+        {
+          "nickname": "updateduser"
+        }
+        """;
+
+    given()
+        .log()
+        .all()
+        .header("Authorization", tokenWithoutBearer) // Bearer 접두사 없음
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(requestBody)
+        .when()
+        .patch("/api/v1/users/me")
+        .then()
+        .log()
+        .all()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+}

--- a/src/test/python/auth-test/auth_test/main.py
+++ b/src/test/python/auth-test/auth_test/main.py
@@ -456,6 +456,8 @@ async def home(request: Request):
                             <p><strong>이메일:</strong> ${{profileData.email}}</p>
                             <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
                             <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
+                            <p><strong>성별:</strong> ${{profileData.gender || 'N/A'}}</p>
+                            <p><strong>출생연도:</strong> ${{profileData.birthYear || 'N/A'}}</p>
                         `;
                         document.getElementById('profileDisplay').innerHTML = profileHtml;
                         document.getElementById('profileInfo').style.display = 'block';
@@ -518,6 +520,8 @@ async def home(request: Request):
                             <p><strong>이메일:</strong> ${{profileData.email}}</p>
                             <p><strong>닉네임:</strong> ${{profileData.nickname}}</p>
                             <p><strong>프로필 이미지:</strong> ${{profileData.profileImage ? `<img src="${{profileData.profileImage}}" style="width: 50px; height: 50px; border-radius: 50%;">` : 'N/A'}}</p>
+                            <p><strong>성별:</strong> ${{profileData.gender || 'N/A'}}</p>
+                            <p><strong>출생연도:</strong> ${{profileData.birthYear || 'N/A'}}</p>
                         `;
                         document.getElementById('myProfileDisplay').innerHTML = profileHtml;
                         document.getElementById('myProfileInfo').style.display = 'block';


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->

- Profile 수정 기능이 추가됩니다. (이메일 제외)
- Profile 조회 시 연령과 성별을 함께 반환합니다.
- 회원 탈퇴 시 kakao 탈퇴도 진행됩니다.
- Profile 수정 시 간단한 validation이 추가됩니다.
- 허용 조건: 성별 = {"M", "F"}, 연령대 = {1900년 ... 올해}

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

Same as above.

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

- 프로필 수정 기능
- 온보딩에 활용 가능한 시나리오 필요
- 앱 제출 시 회원 탈퇴 기능 필수

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

- 사용자가 탈퇴를 하면, 다시 로그인할 경우 아래 스크린샷처럼 새로 가입하는 절차가 진행되는 것을 확인했습니다.
- 사용자 프로필 중 일부의 값만 설정하면, 설정한 값만 정상적으로 수정되는 것 확인했습니다.
- 사용자 탈퇴 후 profile을 조회하면 404 오류가 정상적으로 반환되는 것을 확인했습니다.

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

<img width="443" height="603" alt="image" src="https://github.com/user-attachments/assets/46823d79-9451-4baa-92be-6fa32cab3560" />

<img width="356" height="146" alt="image" src="https://github.com/user-attachments/assets/fcd794b8-7c68-4072-8dbe-d42f719c0206" />

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

새로운 설정 값들이 필요해서, 로컬 테스트나 배포 시에 해당 설정 값들을 세팅해줘야 합니다. 요청 주시면 공유드리겠습니다!

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 수정 API 추가 — 닉네임, 프로필 이미지, 성별, 출생연도 업데이트 가능
  * 계정 삭제 시 카카오 연동 해제 시도 추가
  * 성별 열거 타입 및 출생연도 검증(1900초과, 현재연도 이하) 추가
  * 프로필 응답 및 표시 항목에 성별·출생연도 포함

* **테스트**
  * 프로필 업데이트 E2E 테스트 추가 및 UI 렌더링에 성별·출생연도 표시 확인

* **잡일**
  * DB 마이그레이션으로 사용자 테이블에 성별·출생연도 컬럼 추가
  * 카카오 관리자 키·언링크 URI 구성 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->