### PR TITLE
Fix/서버 사용자 회원가입 API 도메인 영역 변경

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/api/controller/AuthController.java
@@ -2,8 +2,6 @@ package depromeet.lessonfour.server.auth.api.controller;
 
 import static depromeet.lessonfour.server.auth.infra.security.jwt.JwtConstants.REFRESH_TOKEN_COOKIE_NAME;
 
-import java.net.URI;
-
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -25,9 +23,7 @@ import depromeet.lessonfour.server.auth.app.service.RefreshTokenUseCase;
 import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import depromeet.lessonfour.server.user.app.dto.request.LoginRequestDto;
-import depromeet.lessonfour.server.user.app.dto.request.RegisterRequestDto;
 import depromeet.lessonfour.server.user.app.dto.response.AccessTokenResponseDto;
-import depromeet.lessonfour.server.user.app.service.SignupUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,22 +36,8 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
-  private final SignupUseCase registerUseCase;
   private final RefreshTokenUseCase refreshTokenUseCase;
   private final LogoutUseCase logoutUseCase;
-
-  @Operation(
-      summary = "로컬 회원가입",
-      description = "이메일과 비밀번호로 회원가입을 진행합니다. 성공 시 201 Created와 함께 생성된 유저 정보를 반환합니다.")
-  @PostMapping(
-      path = "/signup",
-      consumes = MediaType.APPLICATION_JSON_VALUE,
-      produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> signup(@Valid @RequestBody RegisterRequestDto dto) {
-    // TODO: RESTful하게 users 도메인으로 옮기는 것은 어떨까? e.g. POST users
-    var user = registerUseCase.signup(dto);
-    return ResponseEntity.created(URI.create("/api/v1/users/" + user.id())).body(user);
-  }
 
   @Operation(
       summary = "로컬 로그인",

--- a/src/main/java/depromeet/lessonfour/server/auth/infra/security/config/SecurityConfig.java
+++ b/src/main/java/depromeet/lessonfour/server/auth/infra/security/config/SecurityConfig.java
@@ -124,7 +124,7 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers(
                         "/api/v1/health",
-                        "/api/v1/auth/signup",
+                        "/api/v1/users/signup",
                         "/api/v1/auth/refresh",
                         "/api/v1/auth/*/login",
                         "/api/v1/auth/*/callback",

--- a/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
+++ b/src/main/java/depromeet/lessonfour/server/user/api/controller/UserController.java
@@ -1,5 +1,7 @@
 package depromeet.lessonfour.server.user.api.controller;
 
+import java.net.URI;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -7,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,9 +18,11 @@ import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.user.app.dto.request.RegisterRequestDto;
 import depromeet.lessonfour.server.user.app.dto.request.UpdateUserProfileRequestDto;
 import depromeet.lessonfour.server.user.app.dto.response.UpdateUserProfileResponseDto;
 import depromeet.lessonfour.server.user.app.dto.response.UserProfileResponseDto;
+import depromeet.lessonfour.server.user.app.service.SignupUseCase;
 import depromeet.lessonfour.server.user.app.service.UserDeleteUseCase;
 import depromeet.lessonfour.server.user.app.service.UserQueryService;
 import depromeet.lessonfour.server.user.app.service.UserUpdateService;
@@ -36,6 +41,19 @@ public class UserController {
   private final UserQueryService userQueryService;
   private final UserUpdateService userUpdateService;
   private final UserDeleteUseCase userDeleteUseCase;
+  private final SignupUseCase signupUseCase;
+
+  @Operation(
+      summary = "로컬 회원가입",
+      description = "이메일과 비밀번호로 회원가입을 진행합니다. 성공 시 201 Created와 함께 생성된 유저 정보를 반환합니다.")
+  @PostMapping(
+      path = "/signup",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> signup(@Valid @RequestBody RegisterRequestDto dto) {
+    var user = signupUseCase.signup(dto);
+    return ResponseEntity.created(URI.create("/api/v1/users/" + user.id())).body(user);
+  }
 
   @Operation(
       summary = "내 정보 조회",

--- a/src/test/java/depromeet/lessonfour/server/user/api/controller/SignupE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/user/api/controller/SignupE2ETest.java
@@ -1,4 +1,4 @@
-package depromeet.lessonfour.server.auth.api;
+package depromeet.lessonfour.server.user.api.controller;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -23,7 +23,7 @@ import io.restassured.http.ContentType;
     scripts = "/sql/cleanup.sql",
     config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
     executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-class AuthControllerE2ETest {
+class SignupE2ETest {
 
   @LocalServerPort private int port;
 
@@ -49,7 +49,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.CREATED.value());
   }
@@ -69,7 +69,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -92,7 +92,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -114,7 +114,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -136,7 +136,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -159,7 +159,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -182,7 +182,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -205,7 +205,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -229,7 +229,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.CREATED.value());
 
@@ -247,7 +247,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(duplicateRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.CONFLICT.value());
   }
@@ -269,7 +269,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.CREATED.value());
 
@@ -287,7 +287,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(duplicateRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.CREATED.value());
   }
@@ -301,7 +301,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.JSON)
         .body(invalidRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value());
   }
@@ -315,7 +315,7 @@ class AuthControllerE2ETest {
         .contentType(ContentType.URLENC)
         .body(registerRequest)
         .when()
-        .post("/api/v1/auth/signup")
+        .post("/api/v1/users/signup")
         .then()
         .statusCode(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
   }


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* RESTful하게 signup api의 위치를 auth에서 user로 변경

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 회원가입 엔드포인트가 인증 영역에서 사용자 영역으로 이동하여 가입 경로가 변경되었습니다. 로그인·토큰 갱신·로그아웃 기능은 영향받지 않습니다.
* **테스트**
  * 가입 관련 엔드투엔드 테스트들이 새 경로 및 네임스페이스로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->