### PR TITLE
Fix/누락 필드 존재 시 리포트 500 에러 해결

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/StoolMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/StoolMapper.java
@@ -57,6 +57,9 @@ public class StoolMapper {
       return null;
     }
     HeroCharacter heroCharacter = characterMap.get(stoolReport.getLevel());
+    if (heroCharacter == null) {
+      heroCharacter = characterMap.get(StoolEvaluationLevel.AVERAGE);
+    }
     return new StoolDailyReport(
         stoolReport.getStoolScore(),
         new StoolSummary(

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/StoolReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/StoolReport.java
@@ -2,6 +2,7 @@ package depromeet.lessonfour.server.report.domain.vo;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -41,13 +42,13 @@ public class StoolReport {
   }
 
   public boolean hasBlood() {
-    return items.stream().anyMatch(item -> item.getColor() == ToiletColor.RED);
+    return items.stream().map(StoolEvaluation::getColor).anyMatch(c -> c == ToiletColor.RED);
   }
 
   public boolean hasAbnormalColor() {
     return items.stream()
-        .anyMatch(
-            item -> item.getColor() == ToiletColor.GREEN || item.getColor() == ToiletColor.GRAY);
+        .map(StoolEvaluation::getColor)
+        .anyMatch(c -> c == ToiletColor.GREEN || c == ToiletColor.GRAY);
   }
 
   public boolean drunkAlcohol() {
@@ -77,6 +78,7 @@ public class StoolReport {
   public ToiletShape getMostFrequentShape() {
     return items.stream()
         .map(StoolEvaluation::getShape)
+        .filter(Objects::nonNull)
         .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
         .entrySet()
         .stream()
@@ -88,6 +90,7 @@ public class StoolReport {
   public ToiletColor getMostFrequentColor() {
     return items.stream()
         .map(StoolEvaluation::getColor)
+        .filter(Objects::nonNull)
         .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
         .entrySet()
         .stream()
@@ -97,7 +100,8 @@ public class StoolReport {
   }
 
   public boolean hasGoodShape() {
-    return getMostFrequentShape() == ToiletShape.BANANA;
+    ToiletShape shape = getMostFrequentShape();
+    return shape == ToiletShape.BANANA;
   }
 
   public boolean hasGoodColor() {

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -1,0 +1,253 @@
+package depromeet.lessonfour.server.report.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.food.domain.entity.Food;
+import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class GetDailyReportE2ETest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private JwtTokenGenerator jwtTokenGenerator;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private FoodRepository foodRepository;
+  @Autowired private JpaActivityRecordRepository activityRecordRepository;
+  @Autowired private ToiletRecordRepository toiletRecordRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private String validJwtToken;
+  private Long testUserId;
+  private User testUser;
+  private final DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    testUser = createTestUser("report@example.com", "password123", "report-user");
+    testUserId = testUser.getId();
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+
+    // 최소 1개 식품 확보
+    foodRepository.save(Food.builder().name("사과").score(4.5).build());
+  }
+
+  private User createTestUser(String email, String password, String nickname) {
+    User user = User.register(email, nickname, passwordEncoder.encode(password));
+    return userRepository.save(user);
+  }
+
+  private ActivityRecord createActivity(LocalDateTime dateTime) {
+    List<Food> foods = foodRepository.findAll();
+    List<MealFood> meals = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    return activityRecordRepository.save(
+        ActivityRecord.createWithMeals(
+            testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dateTime), meals));
+  }
+
+  private ToiletRecord createToilet(
+      LocalDateTime dateTime,
+      Boolean isSuccessful,
+      ToiletColor color,
+      ToiletShape shape,
+      Integer pain,
+      Integer duration,
+      String note) {
+    ToiletRecord rec =
+        ToiletRecord.register(
+            testUser,
+            isSuccessful != null ? isSuccessful : true,
+            color, // null 허용
+            shape, // null 허용
+            pain != null ? pain : 10,
+            duration != null ? duration : 5,
+            note,
+            ActivityAt.from(dateTime));
+    toiletRecordRepository.save(rec);
+    return rec;
+  }
+
+  private String url(LocalDateTime dateTime) {
+    return "/api/v1/reports/daily?dateTime=" + dateTime.format(dtf);
+  }
+
+  // 1) toiletrecord + activityrecord 모두 존재
+  @Test
+  @DisplayName("[E2E] toiletrecord + activityrecord 모두 존재 → 정상 리포트 반환")
+  void givenToiletAndActivity_whenGetDailyReport_thenOk() {
+    LocalDateTime base = LocalDateTime.of(2024, 1, 15, 10, 0);
+
+    createActivity(base);
+    createToilet(base.withHour(8), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "메모");
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(base))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.poo", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 2) toiletrecord만 존재
+  @Test
+  @DisplayName("[E2E] toiletrecord만 존재 → 정상 리포트 반환(활동 섹션은 null/빈값 허용)")
+  void givenOnlyToilet_whenGetDailyReport_thenOk() {
+    LocalDateTime base = LocalDateTime.of(2024, 1, 16, 10, 0);
+
+    createToilet(base.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 15, 6, null);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(base))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.poo", notNullValue())
+        // 구현에 따라 food/water/stress 가 null 또는 객체(빈 items)일 수 있어 허용 범위로 체크
+        .body("data.food", anyOf(nullValue(), notNullValue()))
+        .body("data.water", anyOf(nullValue(), notNullValue()))
+        .body("data.stress", anyOf(nullValue(), notNullValue()))
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 3) activityrecord만 존재
+  @Test
+  @DisplayName("[E2E] activityrecord만 존재 → poo(null)이어도 NPE 없이 정상 반환")
+  void givenOnlyActivity_whenGetDailyReport_thenOkAndPooNull() {
+    LocalDateTime base = LocalDateTime.of(2024, 1, 17, 10, 0);
+
+    createActivity(base);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(base))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.poo", nullValue()) // StoolEvaluationLevel.NONE → mapper가 null 반환
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 4) toiletrecord 여러개: isSuccessful=false, color=null, shape=null 섞임
+  @Test
+  @DisplayName("[E2E] toiletrecord 다건(실패/색상null/모양null 포함) → NPE 없이 정상 반환")
+  void givenMultipleToiletWithNullsAndFailure_whenGetDailyReport_thenOk() {
+    LocalDateTime base = LocalDateTime.of(2024, 1, 18, 10, 0);
+
+    createToilet(base.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "ok");
+    createToilet(base.withHour(9), false, ToiletColor.DEFAULT, ToiletShape.ROCK, 30, 12, "fail");
+    createToilet(base.withHour(12), true, null, ToiletShape.CREAM, 5, 3, null); // color null
+    createToilet(base.withHour(18), true, ToiletColor.DARK_BROWN, null, 0, 2, null); // shape null
+    createToilet(base.withHour(20), true, null, null, 25, 8, "둘다 null"); // both null
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(base))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.poo", notNullValue())
+        .body("data.poo.items.size()", equalTo(5))
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 5) toiletrecord 단건: isSuccessful=false, color=null, shape=null
+  @Test
+  @DisplayName("[E2E] toiletrecord 단건(isSuccessful=false, color/shape null) → NPE 없이 정상 반환")
+  void givenSingleToiletWithNullsAndFail_whenGetDailyReport_thenOk() {
+    // Given
+    LocalDateTime base = LocalDateTime.of(2024, 1, 21, 10, 0);
+
+    // activityrecord 없음, toiletrecord 1건만 생성 (실패 + color/shape 모두 null)
+    createToilet(base.withHour(9), false, null, null, 25, 8, "단건 실패/널 케이스");
+
+    // When & Then
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(base))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.poo", notNullValue())
+        .body("data.poo.items.size()", equalTo(1))
+        .body("data.poo.items[0].occurredAt", notNullValue())
+        .body("data.poo.items[0].color", nullValue())
+        .body("data.poo.items[0].shape", nullValue())
+        // 활동 섹션은 구현에 따라 null/객체 모두 허용
+        .body("data.food", anyOf(nullValue(), notNullValue()))
+        .body("data.water", anyOf(nullValue(), notNullValue()))
+        .body("data.stress", anyOf(nullValue(), notNullValue()))
+        .body("data.suggestion", notNullValue());
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #108 

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->
StoolMapper, StoolReport null 안전성 강화, report e2e test 작성

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->
### StoolMapper
- stoolReport.level → characterMap 매핑 시 누락된 enum 값에 대해 기본 캐릭터로 폴백
- 전체적으로 매핑 단계에서 발생하던 NPE 가능성 제거

### StoolReport
- getMostFrequentShape()/getMostFrequentColor()에서 null 필터링 적용 (Objects::nonNull)
- hasBlood()/hasAbnormalColor()는 null color가 포함되어도 안전하게 false로 평가되도록 유지
- hasGoodShape()/hasGoodColor()는 빈도 결과가 null일 때 false 반환되도록 명시적 처리
- 평균/카운트/알코올 감지 로직은 기존 동작 유지

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->
배변 기록 생성 시 color/shape가 null인 경우가 있었고,
리포트 생성 과정에서 NPE가 발생함.

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
E2E 테스트 추가 (/api/v1/reports/daily)
(1) toiletrecord + activityrecord 모두 존재
(2) toiletrecord만 존재
(3) activityrecord만 존재 (poo=null 기대)
(4) toiletrecord 다건: isSuccessful=false, color=null, shape=null 혼재
(5) toiletrecord 단건: isSuccessful=false, color=null, shape=null

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 배변 기록 데이터 매핑 시 누락된 정보에 대한 기본값 설정
- 일일 리포트 생성 시 색상 및 형태 데이터 필터링 강화
- 보고서 데이터 처리에서 null 값 안전 처리 개선

## Tests
- 일일 리포트 API 엔드투엔드 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->