### PR TITLE
Fix/생활기록의 마신 물과 스트레스 null 허용

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/api/dto/request/CreateActivityRecordsRequest.java
@@ -16,9 +16,8 @@ import jakarta.validation.constraints.PositiveOrZero;
 
 public record CreateActivityRecordsRequest(
     @Valid List<CreateFoodRequestDto> foods,
-    @PositiveOrZero(message = "마신 물의 잔 수는 0 이상이어야 합니다") int water,
-    @NotNull(message = "스트레스 지수는 필수입니다") @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다")
-        StressLevel stress,
+    @PositiveOrZero(message = "마신 물의 잔 수는 0 이상이어야 합니다") Integer water,
+    @ValidEnum(enumClass = StressLevel.class, message = "유효하지 않은 스트레스 지수입니다") StressLevel stress,
     @NotNull(message = "선택한 날짜와 시간은 필수입니다") @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
         LocalDateTime occurredAt) {
 

--- a/src/main/java/depromeet/lessonfour/server/activityrecord/domain/entity/ActivityRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/activityrecord/domain/entity/ActivityRecord.java
@@ -49,7 +49,7 @@ public class ActivityRecord extends BaseTimeEntity {
   @Column
   @Min(0)
   @Max(10)
-  private int waterIntakeCups;
+  private Integer waterIntakeCups;
 
   // 스트레스 레벨 (5단계 Enum)
   @Column
@@ -76,7 +76,7 @@ public class ActivityRecord extends BaseTimeEntity {
 
   public static ActivityRecord createWithMeals(
       Long userId,
-      int waterIntakeCups,
+      Integer waterIntakeCups,
       StressLevel stressLevel,
       ActivityAt activityAt,
       List<MealFood> mealFoods) {

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WaterMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WaterMapper.java
@@ -1,6 +1,7 @@
 package depromeet.lessonfour.server.report.api.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
@@ -13,6 +14,14 @@ import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
 
 @Component
 public class WaterMapper {
+
+  static Map<WaterSuggestion, String> COLOR_MAP =
+      Map.of(
+          WaterSuggestion.STANDARD, "#4E5560",
+          WaterSuggestion.HIGH, "#23ABFF",
+          WaterSuggestion.MEDIUM, "#F4B005",
+          WaterSuggestion.LOW, "#F13A49",
+          WaterSuggestion.NONE, "#D9D9D9");
 
   public WaterReport map(List<WaterEvaluation> waterEvaluations) {
     if (waterEvaluations == null || waterEvaluations.isEmpty()) {
@@ -48,10 +57,10 @@ public class WaterMapper {
   private static WaterReportItem mapItem(String name, double value, WaterEvaluation evaluation) {
     if (evaluation == null) {
       return new WaterReportItem(
-          name, value, WaterSuggestion.NONE.getColor(), WaterSuggestion.NONE);
+          name, value, COLOR_MAP.get(WaterSuggestion.NONE), WaterSuggestion.NONE);
     }
     WaterSuggestion suggestion = WaterSuggestion.from(evaluation.getLevel());
-    return new WaterReportItem(name, value, suggestion.getColor(), suggestion);
+    return new WaterReportItem(name, value, COLOR_MAP.get(suggestion), suggestion);
   }
 
   private static WaterEvaluation getEvaluationByDay(

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WaterMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WaterMapper.java
@@ -36,9 +36,8 @@ public class WaterMapper {
         message,
         List.of(
             mapItem("STANDARD", 2000.0, null),
-            mapItem(
-                "YESTERDAY", yesterday != null ? yesterday.getQuantity() * 200 : 0.0, yesterday),
-            mapItem("TODAY", today != null ? today.getQuantity() * 200 : 0.0, today)));
+            mapItem("YESTERDAY", yesterday.getQuantity() * 200, yesterday),
+            mapItem("TODAY", today.getQuantity() * 200, today)));
   }
 
   private static String getMessage(WaterEvaluation evaluation) {
@@ -56,9 +55,11 @@ public class WaterMapper {
 
   private static WaterReportItem mapItem(String name, double value, WaterEvaluation evaluation) {
     if (evaluation == null) {
+      // STANDARD 항목인 경우
       return new WaterReportItem(
           name, value, COLOR_MAP.get(WaterSuggestion.NONE), WaterSuggestion.NONE);
     }
+
     WaterSuggestion suggestion = WaterSuggestion.from(evaluation.getLevel());
     return new WaterReportItem(name, value, COLOR_MAP.get(suggestion), suggestion);
   }
@@ -68,6 +69,6 @@ public class WaterMapper {
     return evaluations.stream()
         .filter(evaluation -> evaluation.getDayType() == dayType)
         .findFirst()
-        .orElse(null);
+        .orElseGet(() -> WaterEvaluation.empty(dayType));
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/StressEvaluationPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/StressEvaluationPolicy.java
@@ -3,8 +3,6 @@ package depromeet.lessonfour.server.report.domain.policy;
 import org.springframework.stereotype.Component;
 
 import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
-import depromeet.lessonfour.server.common.api.code.ErrorCode;
-import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
 
 @Component
@@ -17,7 +15,7 @@ public class StressEvaluationPolicy {
       case MEDIUM -> StressEvaluation.MEDIUM;
       case HIGH -> StressEvaluation.HIGH;
       case VERY_HIGH -> StressEvaluation.VERY_HIGH;
-      default -> throw new ServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+      case null -> StressEvaluation.NONE;
     };
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/WaterEvaluationPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/WaterEvaluationPolicy.java
@@ -9,16 +9,22 @@ import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
 @Component
 public class WaterEvaluationPolicy {
 
-  private static final int HIGH_THRESHOLD = 8;
-  private static final int MEDIUM_THRESHOLD = 5;
+  static final int HIGH_THRESHOLD = 8;
+  static final int MEDIUM_THRESHOLD = 5;
 
-  public WaterEvaluation calculate(int quantity, DayType dayType) {
+  public WaterEvaluation calculate(Integer quantity, DayType dayType) {
+    if (quantity == null) {
+      return WaterEvaluation.empty(dayType);
+    }
+
     if (quantity >= HIGH_THRESHOLD) {
       return new WaterEvaluation(quantity, WaterLevel.HIGH, dayType);
-    } else if (quantity >= MEDIUM_THRESHOLD) {
-      return new WaterEvaluation(quantity, WaterLevel.MEDIUM, dayType);
-    } else {
-      return new WaterEvaluation(quantity, WaterLevel.LOW, dayType);
     }
+
+    if (quantity >= MEDIUM_THRESHOLD) {
+      return new WaterEvaluation(quantity, WaterLevel.MEDIUM, dayType);
+    }
+
+    return new WaterEvaluation(quantity, WaterLevel.LOW, dayType);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/Suggestion.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/Suggestion.java
@@ -25,17 +25,11 @@ public class Suggestion {
 
   @Getter
   public enum WaterSuggestion {
-    STANDARD("#4E5560"),
-    HIGH("#23ABFF"),
-    MEDIUM("#F4B005"),
-    LOW("#F13A49"),
-    NONE("#D9D9D9");
-
-    private final String color;
-
-    WaterSuggestion(String color) {
-      this.color = color;
-    }
+    STANDARD,
+    HIGH,
+    MEDIUM,
+    LOW,
+    NONE;
 
     public static WaterSuggestion from(WaterLevel level) {
       return switch (level) {

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/WaterEvaluation.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/WaterEvaluation.java
@@ -18,4 +18,8 @@ public class WaterEvaluation {
   public static WaterEvaluation empty() {
     return new WaterEvaluation(0, WaterLevel.NONE, DayType.NONE);
   }
+
+  public static WaterEvaluation empty(DayType dayType) {
+    return new WaterEvaluation(0, WaterLevel.NONE, dayType);
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/WaterEvaluation.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/WaterEvaluation.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public class WaterEvaluation {
 
-  private final int quantity;
+  private final Integer quantity;
   private final WaterLevel level;
   private final DayType dayType;
 
-  public WaterEvaluation(int quantity, WaterLevel level, DayType dayType) {
+  public WaterEvaluation(Integer quantity, WaterLevel level, DayType dayType) {
     this.quantity = quantity;
     this.level = level;
     this.dayType = dayType;
@@ -21,5 +21,9 @@ public class WaterEvaluation {
 
   public static WaterEvaluation empty(DayType dayType) {
     return new WaterEvaluation(0, WaterLevel.NONE, dayType);
+  }
+
+  public int getQuantity() {
+    return quantity == null ? 0 : quantity;
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/activityrecord/controllers/CreateActivityRecordE2ETest.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -86,657 +87,688 @@ class CreateActivityRecordE2ETest {
     return jpaUserRepository.save(user);
   }
 
-  @Test
-  @DisplayName("유효한 생활 기록 생성 요청시 성공적으로 생성된다")
-  void givenValidActivityRecordRequest_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            },
-            {
-              "id": %d,
-              "mealTime": "LUNCH"
-            }
-          ],
-          "water": 5,
-          "stress": "MEDIUM",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, bananaId, now.format(formatter));
+  @Nested
+  @DisplayName("성공 케이스")
+  class SuccessCase {
+    @Test
+    @DisplayName("유효한 생활 기록 생성 요청시 성공적으로 생성된다")
+    void givenValidActivityRecordRequest_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              },
+              {
+                "id": %d,
+                "mealTime": "LUNCH"
+              }
+            ],
+            "water": 5,
+            "stress": "MEDIUM",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, bananaId, now.format(formatter));
 
-    given()
-        .log()
-        .all() // 요청 전체 로그 출력
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .log()
-        .all() // 응답 전체 로그 출력
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
+      given()
+          .log()
+          .all() // 요청 전체 로그 출력
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .log()
+          .all() // 응답 전체 로그 출력
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("status", equalTo(201));
+    }
+
+    @Test
+    @DisplayName("모든 식사 시간과 스트레스 레벨로 요청시 성공한다")
+    void givenAllMealTimesAndStressLevels_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              },
+              {
+                "id": %d,
+                "mealTime": "LUNCH"
+              },
+              {
+                "id": %d,
+                "mealTime": "DINNER"
+              },
+              {
+                "id": %d,
+                "mealTime": "SNACK"
+              }
+            ],
+            "water": 10,
+            "stress": "VERY_HIGH",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, bananaId, saladId, burgerId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("status", equalTo(201));
+    }
+
+    @Test
+    @DisplayName("특정 날짜의 생활 기록을 생성했다가 삭제한 후 다시 생성하는 경우 성공한다")
+    void givenCreateDeleteRecreate_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime specificDate = LocalDateTime.of(2024, 1, 15, 14, 30, 0);
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "LUNCH"
+              }
+            ],
+            "water": 3,
+            "stress": "MEDIUM",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, specificDate.format(formatter));
+
+      // 1. 첫 번째 생활 기록 생성
+      given()
+          .log()
+          .all()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .log()
+          .all()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("status", equalTo(201));
+
+      // 생성된 생활 기록 ID 추출 - activityAt으로 조회
+      LocalDateTime startOfDay = specificDate.toLocalDate().atStartOfDay();
+      LocalDateTime endOfDay = specificDate.toLocalDate().atTime(23, 59, 59);
+
+      List<ActivityRecord> activityRecords =
+          activityRecordRepository.findAll().stream()
+              .filter(record -> record.getUserId().equals(testUser.getId()))
+              .filter(record -> !record.isDeleted())
+              .filter(
+                  record -> {
+                    LocalDateTime occurredAt = record.getActivityAt().toDateTime();
+                    return occurredAt.isAfter(startOfDay) && occurredAt.isBefore(endOfDay);
+                  })
+              .toList();
+
+      Long activityRecordId =
+          activityRecords.stream()
+              .findFirst()
+              .map(ActivityRecord::getId)
+              .orElseThrow(() -> new RuntimeException("생성된 ActivityRecord를 찾을 수 없습니다"));
+
+      // 2. 생성된 생활 기록 삭제
+      given()
+          .log()
+          .all()
+          .header("Authorization", validJwtToken)
+          .when()
+          .delete("/api/v1/activity-records/{activityRecordId}", activityRecordId)
+          .then()
+          .log()
+          .all()
+          .statusCode(HttpStatus.OK.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE);
+
+      // 3. 같은 날짜로 다시 생활 기록 생성 (성공해야 함)
+      given()
+          .log()
+          .all()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .log()
+          .all()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("status", equalTo(201));
+
+      // 4. 재생성된 기록이 실제로 존재하는지 확인
+      List<ActivityRecord> recreatedRecords =
+          activityRecordRepository.findAll().stream()
+              .filter(record -> record.getUserId().equals(testUser.getId()))
+              .filter(record -> !record.isDeleted())
+              .filter(
+                  record -> {
+                    LocalDateTime occurredAt = record.getActivityAt().toDateTime();
+                    return occurredAt.isAfter(startOfDay) && occurredAt.isBefore(endOfDay);
+                  })
+              .toList();
+
+      assertThat(recreatedRecords).isNotEmpty();
+    }
   }
 
-  @Test
-  @DisplayName("JWT 토큰 없이 요청시 401 에러를 반환한다")
-  void givenNoAuthToken_whenCreateActivityRecord_thenUnauthorized() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
+  @Nested
+  @DisplayName("인증 실패 케이스")
+  class AuthenticationFailureCase {
+    @Test
+    @DisplayName("JWT 토큰 없이 요청시 401 에러를 반환한다")
+    void givenNoAuthToken_whenCreateActivityRecord_thenUnauthorized() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
 
-    given()
-        .contentType(ContentType.JSON)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.UNAUTHORIZED.value());
+      given()
+          .contentType(ContentType.JSON)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 JWT 토큰으로 요청시 401 에러를 반환한다")
+    void givenInvalidAuthToken_whenCreateActivityRecord_thenUnauthorized() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", "Bearer invalid-token")
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
   }
 
-  @Test
-  @DisplayName("유효하지 않은 JWT 토큰으로 요청시 401 에러를 반환한다")
-  void givenInvalidAuthToken_whenCreateActivityRecord_thenUnauthorized() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
+  @Nested
+  @DisplayName("음식 목록 테스트")
+  class FoodTestCase {
+    @Test
+    @DisplayName("음식 목록이 null인 경우에도 기록을 생성할 수 있다")
+    void givenNullSelectedFoods_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": null,
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              now.format(formatter));
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer invalid-token")
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.UNAUTHORIZED.value());
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    @DisplayName("음식 목록이 빈 배열인 경우에도 기록을 생성할 수 있다")
+    void givenEmptySelectedFoods_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    @DisplayName("음식 ID가 null인 경우 400 에러를 반환한다")
+    void givenNullFoodId_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": null,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("음식 id는 필수입니다"));
+    }
+
+    @Test
+    @DisplayName("식사 시간이 null인 경우 400 에러를 반환한다")
+    void givenNullMealTime_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": null
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("식사 시간은 필수입니다"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 식사 시간인 경우 400 에러를 반환한다")
+    void givenInvalidMealTime_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "INVALID_MEAL_TIME"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("요청 본문이 올바르지 않습니다"));
+    }
   }
 
-  @Test
-  @DisplayName("음식 목록이 null인 경우에도 기록을 생성할 수 있다")
-  void givenNullSelectedFoods_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": null,
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            now.format(formatter));
+  @Nested
+  @DisplayName("물 섭취량 테스트")
+  class WaterIntakeTestCase {
+    @Test
+    @DisplayName("물 섭취량이 음수인 경우 400 에러를 반환한다")
+    void givenNegativeWaterAmount_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": -1,
+            "stress": "LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE);
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("요청 필드 값이 유효하지 않습니다.: water: 마신 물의 잔 수는 0 이상이어야 합니다"));
+    }
+
+    @Test
+    @DisplayName("물 섭취량이 0인 경우 성공한다")
+    void givenZeroWaterAmount_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "SNACK"
+              }
+            ],
+            "water": 0,
+            "stress": "VERY_LOW",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("status", equalTo(201));
+    }
+
+    @Test
+    @DisplayName("물 섭취량이 null인 경우 성공한다")
+    void givenNullWaterAmount_whenCreateActivityRecord_thenSuccess() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "DINNER"
+              }
+            ],
+            "water": null,
+            "stress": "HIGH",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE);
+    }
   }
 
-  @Test
-  @DisplayName("음식 목록이 빈 배열인 경우에도 기록을 생성할 수 있다")
-  void givenEmptySelectedFoods_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            now.format(formatter));
+  @Nested
+  @DisplayName("스트레스 지수 테스트")
+  class StressLevelTestCase {
+    @Test
+    @DisplayName("스트레스 지수가 null인 경우 성공한다")
+    void givenNullStressLevel_whenCreateActivityRecord_thenCreated() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": null,
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE);
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.CREATED.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 스트레스 지수인 경우 400 에러를 반환한다")
+    void givenInvalidStressLevel_whenCreateActivityRecord_thenBadRequest() {
+      LocalDateTime now = LocalDateTime.now();
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "INVALID_STRESS",
+            "occurredAt": "%s"
+          }
+          """,
+              appleId, now.format(formatter));
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("요청 본문이 올바르지 않습니다"));
+    }
   }
 
-  @Test
-  @DisplayName("물 섭취량이 음수인 경우 400 에러를 반환한다")
-  void givenNegativeWaterAmount_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": -1,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
+  @Nested
+  @DisplayName("선택한 날짜와 시간 테스트")
+  class OccurredAtTestCase {
+    @Test
+    @DisplayName("선택한 날짜와 시간이 null인 경우 400 에러를 반환한다")
+    void givenNullSelectedWhen_whenCreateActivityRecord_thenBadRequest() {
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": null
+          }
+          """,
+              appleId);
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("요청 필드 값이 유효하지 않습니다.: water: 마신 물의 잔 수는 0 이상이어야 합니다"));
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value())
+          .contentType(MediaType.APPLICATION_JSON_VALUE)
+          .body("message", containsString("선택한 날짜와 시간은 필수입니다"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 날짜 형식인 경우 400 에러를 반환한다")
+    void givenInvalidDateFormat_whenCreateActivityRecord_thenBadRequest() {
+      String createRequest =
+          String.format(
+              """
+          {
+            "foods": [
+              {
+                "id": %d,
+                "mealTime": "BREAKFAST"
+              }
+            ],
+            "water": 3,
+            "stress": "LOW",
+            "occurredAt": "invalid-date-format"
+          }
+          """,
+              appleId);
+
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(createRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
   }
 
-  @Test
-  @DisplayName("스트레스 지수가 null인 경우 400 에러를 반환한다")
-  void givenNullStressLevel_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": null,
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
+  @Nested
+  @DisplayName("요청 형식 테스트")
+  class RequestFormatTestCase {
+    @Test
+    @DisplayName("JSON 형식이 아닌 요청시 400 에러를 반환한다")
+    void givenNonJsonRequest_whenCreateActivityRecord_thenBadRequest() {
+      String invalidRequest = "not-json-format";
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("스트레스 지수는 필수입니다"));
-  }
+      given()
+          .contentType(ContentType.JSON)
+          .header("Authorization", validJwtToken)
+          .body(invalidRequest)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 
-  @Test
-  @DisplayName("유효하지 않은 스트레스 지수인 경우 400 에러를 반환한다")
-  void givenInvalidStressLevel_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "INVALID_STRESS",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
+    @Test
+    @DisplayName("Content-Type이 application/json이 아닌 경우 415 에러를 반환한다")
+    void givenNonJsonContentType_whenCreateActivityRecord_thenUnsupportedMediaType() {
+      String requestBody = "water=3&stress=LOW";
 
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("요청 본문이 올바르지 않습니다"));
-  }
-
-  @Test
-  @DisplayName("선택한 날짜와 시간이 null인 경우 400 에러를 반환한다")
-  void givenNullSelectedWhen_whenCreateActivityRecord_thenBadRequest() {
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": null
-        }
-        """,
-            appleId);
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("선택한 날짜와 시간은 필수입니다"));
-  }
-
-  @Test
-  @DisplayName("유효하지 않은 날짜 형식인 경우 400 에러를 반환한다")
-  void givenInvalidDateFormat_whenCreateActivityRecord_thenBadRequest() {
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "invalid-date-format"
-        }
-        """,
-            appleId);
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value());
-  }
-
-  @Test
-  @DisplayName("음식 ID가 null인 경우 400 에러를 반환한다")
-  void givenNullFoodId_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": null,
-              "mealTime": "BREAKFAST"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("음식 id는 필수입니다"));
-  }
-
-  @Test
-  @DisplayName("식사 시간이 null인 경우 400 에러를 반환한다")
-  void givenNullMealTime_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": null
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("식사 시간은 필수입니다"));
-  }
-
-  @Test
-  @DisplayName("유효하지 않은 식사 시간인 경우 400 에러를 반환한다")
-  void givenInvalidMealTime_whenCreateActivityRecord_thenBadRequest() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "INVALID_MEAL_TIME"
-            }
-          ],
-          "water": 3,
-          "stress": "LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("message", containsString("요청 본문이 올바르지 않습니다"));
-  }
-
-  @Test
-  @DisplayName("빈 음식 목록으로 요청시 성공한다")
-  void givenEmptyFoodList_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [],
-          "water": 8,
-          "stress": "HIGH",
-          "occurredAt": "%s"
-        }
-        """,
-            now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
-  }
-
-  @Test
-  @DisplayName("물 섭취량이 0인 경우 성공한다")
-  void givenZeroWaterAmount_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "SNACK"
-            }
-          ],
-          "water": 0,
-          "stress": "VERY_LOW",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
-  }
-
-  @Test
-  @DisplayName("모든 식사 시간과 스트레스 레벨로 요청시 성공한다")
-  void givenAllMealTimesAndStressLevels_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime now = LocalDateTime.now();
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "BREAKFAST"
-            },
-            {
-              "id": %d,
-              "mealTime": "LUNCH"
-            },
-            {
-              "id": %d,
-              "mealTime": "DINNER"
-            },
-            {
-              "id": %d,
-              "mealTime": "SNACK"
-            }
-          ],
-          "water": 10,
-          "stress": "VERY_HIGH",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, bananaId, saladId, burgerId, now.format(formatter));
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
-  }
-
-  @Test
-  @DisplayName("JSON 형식이 아닌 요청시 400 에러를 반환한다")
-  void givenNonJsonRequest_whenCreateActivityRecord_thenBadRequest() {
-    String invalidRequest = "not-json-format";
-
-    given()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(invalidRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value());
-  }
-
-  @Test
-  @DisplayName("Content-Type이 application/json이 아닌 경우 415 에러를 반환한다")
-  void givenNonJsonContentType_whenCreateActivityRecord_thenUnsupportedMediaType() {
-    String requestBody = "water=3&stress=LOW";
-
-    given()
-        .contentType(ContentType.URLENC)
-        .header("Authorization", validJwtToken)
-        .body(requestBody)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .statusCode(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
-  }
-
-  @Test
-  @DisplayName("특정 날짜의 생활 기록을 생성했다가 삭제한 후 다시 생성하는 경우 성공한다")
-  void givenCreateDeleteRecreate_whenCreateActivityRecord_thenSuccess() {
-    LocalDateTime specificDate = LocalDateTime.of(2024, 1, 15, 14, 30, 0);
-    String createRequest =
-        String.format(
-            """
-        {
-          "foods": [
-            {
-              "id": %d,
-              "mealTime": "LUNCH"
-            }
-          ],
-          "water": 3,
-          "stress": "MEDIUM",
-          "occurredAt": "%s"
-        }
-        """,
-            appleId, specificDate.format(formatter));
-
-    // 1. 첫 번째 생활 기록 생성
-    given()
-        .log()
-        .all()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .log()
-        .all()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
-
-    // 생성된 생활 기록 ID 추출 - activityAt으로 조회
-    LocalDateTime startOfDay = specificDate.toLocalDate().atStartOfDay();
-    LocalDateTime endOfDay = specificDate.toLocalDate().atTime(23, 59, 59);
-
-    List<ActivityRecord> activityRecords =
-        activityRecordRepository.findAll().stream()
-            .filter(record -> record.getUserId().equals(testUser.getId()))
-            .filter(record -> !record.isDeleted())
-            .filter(
-                record -> {
-                  LocalDateTime occurredAt = record.getActivityAt().toDateTime();
-                  return occurredAt.isAfter(startOfDay) && occurredAt.isBefore(endOfDay);
-                })
-            .toList();
-
-    Long activityRecordId =
-        activityRecords.stream()
-            .findFirst()
-            .map(ActivityRecord::getId)
-            .orElseThrow(() -> new RuntimeException("생성된 ActivityRecord를 찾을 수 없습니다"));
-
-    // 2. 생성된 생활 기록 삭제
-    given()
-        .log()
-        .all()
-        .header("Authorization", validJwtToken)
-        .when()
-        .delete("/api/v1/activity-records/{activityRecordId}", activityRecordId)
-        .then()
-        .log()
-        .all()
-        .statusCode(HttpStatus.OK.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE);
-
-    // 3. 같은 날짜로 다시 생활 기록 생성 (성공해야 함)
-    given()
-        .log()
-        .all()
-        .contentType(ContentType.JSON)
-        .header("Authorization", validJwtToken)
-        .body(createRequest)
-        .when()
-        .post("/api/v1/activity-records")
-        .then()
-        .log()
-        .all()
-        .statusCode(HttpStatus.CREATED.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(201));
-
-    // 4. 재생성된 기록이 실제로 존재하는지 확인
-    List<ActivityRecord> recreatedRecords =
-        activityRecordRepository.findAll().stream()
-            .filter(record -> record.getUserId().equals(testUser.getId()))
-            .filter(record -> !record.isDeleted())
-            .filter(
-                record -> {
-                  LocalDateTime occurredAt = record.getActivityAt().toDateTime();
-                  return occurredAt.isAfter(startOfDay) && occurredAt.isBefore(endOfDay);
-                })
-            .toList();
-
-    assertThat(recreatedRecords).isNotEmpty();
+      given()
+          .contentType(ContentType.URLENC)
+          .header("Authorization", validJwtToken)
+          .body(requestBody)
+          .when()
+          .post("/api/v1/activity-records")
+          .then()
+          .statusCode(HttpStatus.UNSUPPORTED_MEDIA_TYPE.value());
+    }
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/StressMapperTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/StressMapperTest.java
@@ -1,0 +1,113 @@
+package depromeet.lessonfour.server.report.api.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.StressReport;
+import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
+
+@DisplayName("StressMapper 테스트")
+class StressMapperTest {
+
+  StressMapper mapper = new StressMapper();
+
+  @Test
+  @DisplayName("VERY_LOW 스트레스 평가는 적절한 메시지와 이미지를 반환한다")
+  void givenVeryLowStressEvaluation_whenMap_thenReturnCorrectStressReport() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.VERY_LOW;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.message()).isEqualTo("삐용삐용! 스트레스 만땅! 산책이나 명상을 해볼까요?");
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_very_bad.png");
+  }
+
+  @Test
+  @DisplayName("LOW 스트레스 평가는 적절한 메시지와 이미지를 반환한다")
+  void givenLowStressEvaluation_whenMap_thenReturnCorrectStressReport() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.LOW;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.message()).isEqualTo("스트레스에 잡아먹히지 않도록 조심해봐요!");
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_bad.png");
+  }
+
+  @Test
+  @DisplayName("MEDIUM 스트레스 평가는 적절한 메시지와 이미지를 반환한다")
+  void givenMediumStressEvaluation_whenMap_thenReturnCorrectStressReport() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.MEDIUM;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.message()).isEqualTo("스트레스 발생! 마음을 다스릴 수 있도록 노력해요");
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
+  }
+
+  @Test
+  @DisplayName("HIGH 스트레스 평가는 적절한 메시지와 이미지를 반환한다")
+  void givenHighStressEvaluation_whenMap_thenReturnCorrectStressReport() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.HIGH;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.message()).isEqualTo("긍정적인 당신! 그 마인드 오래도록 유지해봐요");
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_good.png");
+  }
+
+  @Test
+  @DisplayName("VERY_HIGH 스트레스 평가는 적절한 메시지와 이미지를 반환한다")
+  void givenVeryHighStressEvaluation_whenMap_thenReturnCorrectStressReport() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.VERY_HIGH;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.message()).isEqualTo("스트레스 Zero! 행복한 하루가 되셨군요?");
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_very_good.png");
+  }
+
+  @Test
+  @DisplayName("NONE 스트레스 평가는 null을 반환한다")
+  void givenNoneStressEvaluation_whenMap_thenReturnNull() {
+    // given
+    StressEvaluation evaluation = StressEvaluation.NONE;
+
+    // when
+    StressReport result = mapper.map(evaluation);
+
+    // then
+    assertThat(result).isNull();
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/WaterMapperTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/WaterMapperTest.java
@@ -1,0 +1,402 @@
+package depromeet.lessonfour.server.report.api.mapper;
+
+import static depromeet.lessonfour.server.report.api.mapper.WaterMapper.COLOR_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.WaterReport;
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.WaterReportItem;
+import depromeet.lessonfour.server.report.domain.vo.DayType;
+import depromeet.lessonfour.server.report.domain.vo.Suggestion.WaterSuggestion;
+import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
+
+@DisplayName("WaterMapper 테스트")
+class WaterMapperTest {
+
+  private WaterMapper waterMapper;
+
+  @BeforeEach
+  void setUp() {
+    waterMapper = new WaterMapper();
+  }
+
+  @Nested
+  @DisplayName("map() 메서드 테스트")
+  class MapMethod {
+
+    @Nested
+    @DisplayName("입력값이 null이거나 비어있는 경우")
+    class WhenInputIsNullOrEmpty {
+
+      @Test
+      @DisplayName("null이 입력되면 null을 반환한다")
+      void shouldReturnNullWhenInputIsNull() {
+        // given
+        List<WaterEvaluation> waterEvaluations = null;
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNull();
+      }
+
+      @Test
+      @DisplayName("빈 리스트가 입력되면 null을 반환한다")
+      void shouldReturnNullWhenInputIsEmpty() {
+        // given
+        List<WaterEvaluation> waterEvaluations = Collections.emptyList();
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNull();
+      }
+    }
+
+    @Nested
+    @DisplayName("오늘과 어제 데이터가 모두 있는 경우")
+    class WhenBothTodayAndYesterdayExist {
+
+      @Test
+      @DisplayName("HIGH 레벨일 때 성공 메시지와 적절한 데이터를 반환한다")
+      void shouldReturnSuccessMessageForHighLevel() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(10, WaterLevel.HIGH, DayType.TODAY);
+        WaterEvaluation yesterday = new WaterEvaluation(8, WaterLevel.MEDIUM, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.message()).isEqualTo("훌륭해요! 물 섭취 만점입니다. 앞으로도 잘 유지해봐요");
+        assertThat(result.items()).hasSize(3);
+
+        // STANDARD 항목 검증
+        WaterReportItem standardItem = result.items().getFirst();
+        assertThat(standardItem.name()).isEqualTo("STANDARD");
+        assertThat(standardItem.value()).isEqualTo(2000.0);
+        assertThat(standardItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.NONE));
+        assertThat(standardItem.level()).isEqualTo(WaterSuggestion.NONE);
+
+        // YESTERDAY 항목 검증
+        WaterReportItem yesterdayItem = result.items().get(1);
+        assertThat(yesterdayItem.name()).isEqualTo("YESTERDAY");
+        assertThat(yesterdayItem.value()).isEqualTo(1600.0); // 8 * 200
+        assertThat(yesterdayItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.MEDIUM));
+        assertThat(yesterdayItem.level()).isEqualTo(WaterSuggestion.MEDIUM);
+
+        // TODAY 항목 검증
+        WaterReportItem todayItem = result.items().get(2);
+        assertThat(todayItem.name()).isEqualTo("TODAY");
+        assertThat(todayItem.value()).isEqualTo(2000.0); // 10 * 200
+        assertThat(todayItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.HIGH));
+        assertThat(todayItem.level()).isEqualTo(WaterSuggestion.HIGH);
+      }
+
+      @Test
+      @DisplayName("MEDIUM 레벨일 때 보통 메시지를 반환한다")
+      void shouldReturnMediumMessageForMediumLevel() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(7, WaterLevel.MEDIUM, DayType.TODAY);
+        WaterEvaluation yesterday = new WaterEvaluation(6, WaterLevel.LOW, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.message()).isEqualTo("보통 수준이에요. 조금 더 자주 물을 마셔보세요!");
+        assertThat(result.items().get(2).value()).isEqualTo(1400.0); // 7 * 200
+        assertThat(result.items().get(2).level()).isEqualTo(WaterSuggestion.MEDIUM);
+      }
+
+      @Test
+      @DisplayName("LOW 레벨일 때 경고 메시지를 반환한다")
+      void shouldReturnWarningMessageForLowLevel() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(3, WaterLevel.LOW, DayType.TODAY);
+        WaterEvaluation yesterday = new WaterEvaluation(5, WaterLevel.MEDIUM, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.message()).isEqualTo("장이 말라가고 있어요! 물 섭취량을 늘려야 해요");
+        assertThat(result.items().get(2).value()).isEqualTo(600.0); // 3 * 200
+        assertThat(result.items().get(2).level()).isEqualTo(WaterSuggestion.LOW);
+      }
+
+      @Test
+      @DisplayName("NONE 레벨일 때 기록 없음 메시지를 반환한다")
+      void shouldReturnNoRecordMessageForNoneLevel() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
+        WaterEvaluation yesterday = new WaterEvaluation(5, WaterLevel.MEDIUM, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.message()).isEqualTo("물 섭취 기록이 없어요. 물을 자주 마셔주세요");
+        assertThat(result.items().get(2).value()).isEqualTo(0.0);
+        assertThat(result.items().get(2).level()).isEqualTo(WaterSuggestion.NONE);
+      }
+    }
+
+    @Nested
+    @DisplayName("오늘 데이터만 있는 경우")
+    class WhenOnlyTodayExists {
+
+      @Test
+      @DisplayName("어제 데이터가 없으면 어제 항목은 0으로 처리된다")
+      void shouldHandleMissingYesterdayData() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(8, WaterLevel.MEDIUM, DayType.TODAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.items()).hasSize(3);
+
+        // YESTERDAY 항목 검증 - null evaluation이므로 0.0
+        WaterReportItem yesterdayItem = result.items().get(1);
+        assertThat(yesterdayItem.name()).isEqualTo("YESTERDAY");
+        assertThat(yesterdayItem.value()).isEqualTo(0.0);
+        assertThat(yesterdayItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.NONE));
+        assertThat(yesterdayItem.level()).isEqualTo(WaterSuggestion.NONE);
+
+        // TODAY 항목 검증
+        WaterReportItem todayItem = result.items().get(2);
+        assertThat(todayItem.name()).isEqualTo("TODAY");
+        assertThat(todayItem.value()).isEqualTo(1600.0); // 8 * 200
+      }
+    }
+
+    @Nested
+    @DisplayName("어제 데이터만 있는 경우")
+    class WhenOnlyYesterdayExists {
+
+      @Test
+      @DisplayName("오늘 데이터가 없으면 기본 메시지를 반환하고 오늘 항목은 0으로 처리된다")
+      void shouldHandleMissingTodayData() {
+        // given
+        WaterEvaluation yesterday = new WaterEvaluation(9, WaterLevel.HIGH, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.message()).isEqualTo("물 섭취 기록이 없어요. 물을 자주 마셔주세요");
+        assertThat(result.items()).hasSize(3);
+
+        // YESTERDAY 항목 검증
+        WaterReportItem yesterdayItem = result.items().get(1);
+        assertThat(yesterdayItem.name()).isEqualTo("YESTERDAY");
+        assertThat(yesterdayItem.value()).isEqualTo(1800.0); // 9 * 200
+
+        // TODAY 항목 검증 - null evaluation이므로 0.0
+        WaterReportItem todayItem = result.items().get(2);
+        assertThat(todayItem.name()).isEqualTo("TODAY");
+        assertThat(todayItem.value()).isEqualTo(0.0);
+        assertThat(todayItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.NONE));
+        assertThat(todayItem.level()).isEqualTo(WaterSuggestion.NONE);
+      }
+    }
+
+    @Nested
+    @DisplayName("quantity가 0인 경우")
+    class WhenQuantityIsZero {
+
+      @Test
+      @DisplayName("quantity가 0이면 value도 0이 된다")
+      void shouldHandleZeroQuantity() {
+        // given
+        WaterEvaluation today = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
+        WaterEvaluation yesterday = new WaterEvaluation(0, WaterLevel.NONE, DayType.YESTERDAY);
+        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+        // when
+        WaterReport result = waterMapper.map(waterEvaluations);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.items().get(1).value()).isEqualTo(0.0); // YESTERDAY
+        assertThat(result.items().get(2).value()).isEqualTo(0.0); // TODAY
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("WaterSuggestion과 WaterLevel 매핑 테스트")
+  class WaterSuggestionMapping {
+
+    @Test
+    @DisplayName("HIGH 레벨은 HIGH suggestion과 파란색으로 매핑된다")
+    void shouldMapHighLevelCorrectly() {
+      // given
+      WaterEvaluation evaluation = new WaterEvaluation(10, WaterLevel.HIGH, DayType.TODAY);
+
+      // when
+      WaterReport result = waterMapper.map(List.of(evaluation));
+
+      // then
+      WaterReportItem todayItem = result.items().get(2);
+      assertThat(todayItem.level()).isEqualTo(WaterSuggestion.HIGH);
+      assertThat(todayItem.color()).isEqualTo("#23ABFF");
+    }
+
+    @Test
+    @DisplayName("MEDIUM 레벨은 MEDIUM suggestion과 주황색으로 매핑된다")
+    void shouldMapMediumLevelCorrectly() {
+      // given
+      WaterEvaluation evaluation = new WaterEvaluation(7, WaterLevel.MEDIUM, DayType.TODAY);
+
+      // when
+      WaterReport result = waterMapper.map(List.of(evaluation));
+
+      // then
+      WaterReportItem todayItem = result.items().get(2);
+      assertThat(todayItem.level()).isEqualTo(WaterSuggestion.MEDIUM);
+      assertThat(todayItem.color()).isEqualTo("#F4B005");
+    }
+
+    @Test
+    @DisplayName("LOW 레벨은 LOW suggestion과 빨간색으로 매핑된다")
+    void shouldMapLowLevelCorrectly() {
+      // given
+      WaterEvaluation evaluation = new WaterEvaluation(3, WaterLevel.LOW, DayType.TODAY);
+
+      // when
+      WaterReport result = waterMapper.map(List.of(evaluation));
+
+      // then
+      WaterReportItem todayItem = result.items().get(2);
+      assertThat(todayItem.level()).isEqualTo(WaterSuggestion.LOW);
+      assertThat(todayItem.color()).isEqualTo("#F13A49");
+    }
+
+    @Test
+    @DisplayName("NONE 레벨은 NONE suggestion과 회색으로 매핑된다")
+    void shouldMapNoneLevelCorrectly() {
+      // given
+      WaterEvaluation evaluation = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
+
+      // when
+      WaterReport result = waterMapper.map(List.of(evaluation));
+
+      // then
+      WaterReportItem todayItem = result.items().get(2);
+      assertThat(todayItem.level()).isEqualTo(WaterSuggestion.NONE);
+      assertThat(todayItem.color()).isEqualTo("#D9D9D9");
+    }
+  }
+
+  @Nested
+  @DisplayName("STANDARD 항목 테스트")
+  class StandardItemTest {
+
+    @Test
+    @DisplayName("STANDARD 항목은 항상 2000.0 값과 NONE suggestion을 가진다")
+    void shouldAlwaysHaveStandardItemWithFixedValues() {
+      // given
+      WaterEvaluation today = new WaterEvaluation(10, WaterLevel.HIGH, DayType.TODAY);
+      List<WaterEvaluation> waterEvaluations = List.of(today);
+
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
+
+      // then
+      WaterReportItem standardItem = result.items().getFirst();
+      assertThat(standardItem.name()).isEqualTo("STANDARD");
+      assertThat(standardItem.value()).isEqualTo(2000.0);
+      assertThat(standardItem.color()).isEqualTo(COLOR_MAP.get(WaterSuggestion.NONE));
+      assertThat(standardItem.level()).isEqualTo(WaterSuggestion.NONE);
+    }
+  }
+
+  @Nested
+  @DisplayName("메시지 생성 테스트")
+  class MessageGenerationTest {
+
+    @Test
+    @DisplayName("모든 WaterLevel에 대해 적절한 메시지가 생성된다")
+    void shouldGenerateAppropriateMessagesForAllLevels() {
+      // HIGH
+      WaterEvaluation high = new WaterEvaluation(10, WaterLevel.HIGH, DayType.TODAY);
+      WaterReport highResult = waterMapper.map(List.of(high));
+      assertThat(highResult.message()).isEqualTo("훌륭해요! 물 섭취 만점입니다. 앞으로도 잘 유지해봐요");
+
+      // MEDIUM
+      WaterEvaluation medium = new WaterEvaluation(7, WaterLevel.MEDIUM, DayType.TODAY);
+      WaterReport mediumResult = waterMapper.map(List.of(medium));
+      assertThat(mediumResult.message()).isEqualTo("보통 수준이에요. 조금 더 자주 물을 마셔보세요!");
+
+      // LOW
+      WaterEvaluation low = new WaterEvaluation(3, WaterLevel.LOW, DayType.TODAY);
+      WaterReport lowResult = waterMapper.map(List.of(low));
+      assertThat(lowResult.message()).isEqualTo("장이 말라가고 있어요! 물 섭취량을 늘려야 해요");
+
+      // NONE
+      WaterEvaluation none = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
+      WaterReport noneResult = waterMapper.map(List.of(none));
+      assertThat(noneResult.message()).isEqualTo("물 섭취 기록이 없어요. 물을 자주 마셔주세요");
+    }
+  }
+
+  @Nested
+  @DisplayName("수량 계산 테스트")
+  class QuantityCalculationTest {
+
+    @Test
+    @DisplayName("quantity는 200을 곱해서 value로 변환된다")
+    void shouldMultiplyQuantityBy200() {
+      // given
+      WaterEvaluation today = new WaterEvaluation(5, WaterLevel.MEDIUM, DayType.TODAY);
+      WaterEvaluation yesterday = new WaterEvaluation(3, WaterLevel.LOW, DayType.YESTERDAY);
+      List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
+
+      // then
+      assertThat(result.items().get(1).value()).isEqualTo(600.0); // 3 * 200
+      assertThat(result.items().get(2).value()).isEqualTo(1000.0); // 5 * 200
+    }
+
+    @Test
+    @DisplayName("큰 수량도 올바르게 계산된다")
+    void shouldHandleLargeQuantities() {
+      // given
+      WaterEvaluation today = new WaterEvaluation(15, WaterLevel.HIGH, DayType.TODAY);
+      List<WaterEvaluation> waterEvaluations = List.of(today);
+
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
+
+      // then
+      assertThat(result.items().get(2).value()).isEqualTo(3000.0); // 15 * 200
+    }
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/WaterMapperTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/WaterMapperTest.java
@@ -32,35 +32,30 @@ class WaterMapperTest {
   @DisplayName("map() 메서드 테스트")
   class MapMethod {
 
-    @Nested
-    @DisplayName("입력값이 null이거나 비어있는 경우")
-    class WhenInputIsNullOrEmpty {
+    @Test
+    @DisplayName("null이 입력되면 null을 반환한다")
+    void shouldReturnNullWhenInputIsNull() {
+      // given
+      List<WaterEvaluation> waterEvaluations = null;
 
-      @Test
-      @DisplayName("null이 입력되면 null을 반환한다")
-      void shouldReturnNullWhenInputIsNull() {
-        // given
-        List<WaterEvaluation> waterEvaluations = null;
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
 
-        // when
-        WaterReport result = waterMapper.map(waterEvaluations);
+      // then
+      assertThat(result).isNull();
+    }
 
-        // then
-        assertThat(result).isNull();
-      }
+    @Test
+    @DisplayName("빈 리스트가 입력되면 null을 반환한다")
+    void shouldReturnNullWhenInputIsEmpty() {
+      // given
+      List<WaterEvaluation> waterEvaluations = Collections.emptyList();
 
-      @Test
-      @DisplayName("빈 리스트가 입력되면 null을 반환한다")
-      void shouldReturnNullWhenInputIsEmpty() {
-        // given
-        List<WaterEvaluation> waterEvaluations = Collections.emptyList();
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
 
-        // when
-        WaterReport result = waterMapper.map(waterEvaluations);
-
-        // then
-        assertThat(result).isNull();
-      }
+      // then
+      assertThat(result).isNull();
     }
 
     @Nested
@@ -225,26 +220,21 @@ class WaterMapperTest {
       }
     }
 
-    @Nested
-    @DisplayName("quantity가 0인 경우")
-    class WhenQuantityIsZero {
+    @Test
+    @DisplayName("quantity가 0이면 value도 0이 된다")
+    void shouldHandleZeroQuantity() {
+      // given
+      WaterEvaluation today = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
+      WaterEvaluation yesterday = new WaterEvaluation(0, WaterLevel.NONE, DayType.YESTERDAY);
+      List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
 
-      @Test
-      @DisplayName("quantity가 0이면 value도 0이 된다")
-      void shouldHandleZeroQuantity() {
-        // given
-        WaterEvaluation today = new WaterEvaluation(0, WaterLevel.NONE, DayType.TODAY);
-        WaterEvaluation yesterday = new WaterEvaluation(0, WaterLevel.NONE, DayType.YESTERDAY);
-        List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
 
-        // when
-        WaterReport result = waterMapper.map(waterEvaluations);
-
-        // then
-        assertThat(result).isNotNull();
-        assertThat(result.items().get(1).value()).isEqualTo(0.0); // YESTERDAY
-        assertThat(result.items().get(2).value()).isEqualTo(0.0); // TODAY
-      }
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.items().get(1).value()).isEqualTo(0.0); // YESTERDAY
+      assertThat(result.items().get(2).value()).isEqualTo(0.0); // TODAY
     }
   }
 
@@ -397,6 +387,23 @@ class WaterMapperTest {
 
       // then
       assertThat(result.items().get(2).value()).isEqualTo(3000.0); // 15 * 200
+    }
+
+    @Test
+    @DisplayName("quantity가 null인 경우 0으로 처리한다")
+    void shouldHandleZeroQuantity() {
+      // given
+      WaterEvaluation today = new WaterEvaluation(null, WaterLevel.NONE, DayType.TODAY);
+      WaterEvaluation yesterday = new WaterEvaluation(null, WaterLevel.NONE, DayType.YESTERDAY);
+      List<WaterEvaluation> waterEvaluations = List.of(today, yesterday);
+
+      // when
+      WaterReport result = waterMapper.map(waterEvaluations);
+
+      // then
+      assertThat(result).isNotNull();
+      assertThat(result.items().get(1).value()).isEqualTo(0.0);
+      assertThat(result.items().get(2).value()).isEqualTo(0.0);
     }
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/domain/policy/StressEvaluationPolicyTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/domain/policy/StressEvaluationPolicyTest.java
@@ -1,0 +1,26 @@
+package depromeet.lessonfour.server.report.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
+
+@DisplayName("StressEvaluationPolicy 테스트")
+class StressEvaluationPolicyTest {
+
+  StressEvaluationPolicy policy = new StressEvaluationPolicy();
+
+  @Test
+  @DisplayName("스트레스 레벨에 따른 스트레스 평가가 올바르게 계산된다.")
+  void givenStressLevel_whenCalculate_thenReturnCorrectStressEvaluation() {
+    assertThat(policy.calculate(StressLevel.VERY_LOW)).isEqualTo(StressEvaluation.VERY_LOW);
+    assertThat(policy.calculate(StressLevel.LOW)).isEqualTo(StressEvaluation.LOW);
+    assertThat(policy.calculate(StressLevel.MEDIUM)).isEqualTo(StressEvaluation.MEDIUM);
+    assertThat(policy.calculate(StressLevel.HIGH)).isEqualTo(StressEvaluation.HIGH);
+    assertThat(policy.calculate(StressLevel.VERY_HIGH)).isEqualTo(StressEvaluation.VERY_HIGH);
+    assertThat(policy.calculate(null)).isEqualTo(StressEvaluation.NONE);
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/domain/policy/WaterEvaluationPolicyTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/domain/policy/WaterEvaluationPolicyTest.java
@@ -1,0 +1,87 @@
+package depromeet.lessonfour.server.report.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.domain.vo.DayType;
+import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
+
+@DisplayName("WaterEvaluationPolicy 테스트")
+class WaterEvaluationPolicyTest {
+
+  WaterEvaluationPolicy policy = new WaterEvaluationPolicy();
+
+  @Test
+  @DisplayName("물 섭취량이 null인 경우 빈 평가 객체를 반환한다.")
+  void givenNullQuantity_whenCalculate_thenReturnEmptyEvaluation() {
+    // given
+    Integer quantity = null;
+    DayType dayType = DayType.TODAY;
+
+    // when
+    WaterEvaluation evaluation = policy.calculate(quantity, dayType);
+
+    // then
+    assertThat(evaluation.getQuantity()).isZero();
+    assertThat(evaluation.getLevel()).isEqualTo(WaterLevel.NONE);
+  }
+
+  @Test
+  @DisplayName("물 섭취량이 null인 경우 생성되는 평가 객체의 DayType이 올바르게 설정된다.")
+  void givenNullQuantity_whenCalculate_thenReturnEvaluationWithCorrectDayType() {
+    // given
+    Integer quantity = null;
+    DayType dayType = DayType.YESTERDAY;
+
+    // when
+    WaterEvaluation evaluation = policy.calculate(quantity, dayType);
+
+    // then
+    assertThat(evaluation.getDayType()).isEqualTo(DayType.YESTERDAY);
+  }
+
+  @Test
+  @DisplayName("물 섭취량이 HIGH_THRESHOLD인 경우 HIGH 레벨의 평가 객체를 반환한다.")
+  void givenHighQuantity_whenCalculate_thenReturnHighLevelEvaluation() {
+    // given
+    Integer quantity = WaterEvaluationPolicy.HIGH_THRESHOLD;
+    DayType dayType = DayType.TODAY;
+
+    // when
+    WaterEvaluation evaluation = policy.calculate(quantity, dayType);
+
+    // then
+    assertThat(evaluation.getLevel()).isEqualTo(WaterLevel.HIGH);
+  }
+
+  @Test
+  @DisplayName("물 섭취량이 MEDIUM_THRESHOLD인 경우 MEDIUM 레벨의 평가 객체를 반환한다.")
+  void givenMediumQuantity_whenCalculate_thenReturnMediumLevelEvaluation() {
+    // given
+    Integer quantity = WaterEvaluationPolicy.MEDIUM_THRESHOLD;
+    DayType dayType = DayType.TODAY;
+
+    // when
+    WaterEvaluation evaluation = policy.calculate(quantity, dayType);
+
+    // then
+    assertThat(evaluation.getLevel()).isEqualTo(WaterLevel.MEDIUM);
+  }
+
+  @Test
+  @DisplayName("물 섭취량이 MEDIUM_THRESHOLD 미만인 경우 LOW 레벨의 평가 객체를 반환한다.")
+  void givenLowQuantity_whenCalculate_thenReturnLowLevelEvaluation() {
+    // given
+    Integer quantity = WaterEvaluationPolicy.MEDIUM_THRESHOLD - 1;
+    DayType dayType = DayType.TODAY;
+
+    // when
+    WaterEvaluation evaluation = policy.calculate(quantity, dayType);
+
+    // then
+    assertThat(evaluation.getLevel()).isEqualTo(WaterLevel.LOW);
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 생활기록의 마신 물의 수와 스트레스에 null 허용
* 일간 리포트 마신 물의 수와 스트레스가 null인 경우 정상적으로 리포트를 생성하도록 수정
  * unit test 추가
* 일간 리포트 그래프 색상을 api 계층으로 분리

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 물 섭취량 기록을 선택적으로 변경하여 더 유연한 데이터 입력 지원
  * 스트레스 및 물 섭취량 평가 로직의 null 안전성 강화
  * 입력 값 검증 규칙 최적화

* **테스트**
  * 평가 정책 및 데이터 매핑 검증을 위한 단위 테스트 추가
  * 엔드-투-엔드 테스트 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->