### PR TITLE
Feat/주간, 월간 리포트 및 홈 조회 구현

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/recordquery/api/controller/HomeController.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/api/controller/HomeController.java
@@ -1,0 +1,38 @@
+package depromeet.lessonfour.server.recordquery.api.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import depromeet.lessonfour.server.common.api.code.SuccessCode;
+import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
+import depromeet.lessonfour.server.recordquery.app.dto.HomeResponseDto;
+import depromeet.lessonfour.server.recordquery.app.service.GetDailyRecordUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@Tag(name = "홈", description = "홈 관련 API 문서입니다.")
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+  private final GetDailyRecordUseCase getDailyRecordUseCase;
+
+  @Operation(summary = "홈 데이터 조회", description = "특정 날짜의 홈 화면 정보를 조회합니다.")
+  @GetMapping("/{date}")
+  public SuccessResponse<HomeResponseDto> getHome(
+      @AuthenticationPrincipal(expression = "id") Long userId,
+      @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    return SuccessResponse.of(
+        SuccessCode.SUCCESS_FETCH, getDailyRecordUseCase.getHomeRecord(userId, date));
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ToiletRecordClient.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ToiletRecordClient.java
@@ -11,4 +11,8 @@ public interface ToiletRecordClient {
       Long userId, ActivityAt startInclude, ActivityAt endInclude);
 
   int getToiletRecordCountByActivityAt(Long userId, ActivityAt activityAt);
+
+  HeroAssets getToiletHeroAssets(int score);
+
+  record HeroAssets(String image, List<String> backgroundColors) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/dto/HomeResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/dto/HomeResponseDto.java
@@ -1,0 +1,9 @@
+package depromeet.lessonfour.server.recordquery.app.dto;
+
+import java.util.List;
+
+public record HomeResponseDto(
+    int toiletRecordCount,
+    boolean hasActivityRecord,
+    String heroImage,
+    List<String> heroBackgroundColors) {}

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/service/GetDailyRecordUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/service/GetDailyRecordUseCase.java
@@ -8,6 +8,7 @@ import depromeet.lessonfour.server.recordquery.app.client.ActivityRecordClient;
 import depromeet.lessonfour.server.recordquery.app.client.ReportClient;
 import depromeet.lessonfour.server.recordquery.app.client.ToiletRecordClient;
 import depromeet.lessonfour.server.recordquery.app.dto.DailyRecordResponse;
+import depromeet.lessonfour.server.recordquery.app.dto.HomeResponseDto;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -26,5 +27,18 @@ public class GetDailyRecordUseCase {
     boolean activityRecordExists = activityRecordClient.existsByActivityAt(userId, activityAt);
 
     return new DailyRecordResponse(score, toiletRecordCount, activityRecordExists);
+  }
+
+  public HomeResponseDto getHomeRecord(Long userId, LocalDate date) {
+    ActivityAt activityAt = ActivityAt.of(date);
+
+    int score = reportClient.getScoreByActivityAt(userId, activityAt);
+    var hero = toiletRecordClient.getToiletHeroAssets(score);
+
+    int toiletRecordCount = toiletRecordClient.getToiletRecordCountByActivityAt(userId, activityAt);
+    boolean activityRecordExists = activityRecordClient.existsByActivityAt(userId, activityAt);
+
+    return new HomeResponseDto(
+        toiletRecordCount, activityRecordExists, hero.image(), hero.backgroundColors());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
@@ -31,9 +31,9 @@ public class ToiletRecordClientImpl implements ToiletRecordClient {
   }
 
   @Override
-  public HeroAssets getToiletHeroAssets(int score) {
+  public ToiletRecordClient.HeroAssets getToiletHeroAssets(int score) {
     var level = ToiletEvaluationLevel.from(score);
     var assets = toiletReportMapper.heroAssetsByLevel(level);
-    return new HeroAssets(assets.image(), assets.backgroundColors());
+    return new ToiletRecordClient.HeroAssets(assets.image(), assets.backgroundColors());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.common.domain.vo.DailyExistence;
 import depromeet.lessonfour.server.recordquery.app.client.ToiletRecordClient;
+import depromeet.lessonfour.server.report.api.mapper.ToiletReportMapper;
+import depromeet.lessonfour.server.report.domain.vo.ToiletEvaluationLevel;
 import depromeet.lessonfour.server.toiletrecord.app.service.ToiletRecordQueryService;
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class ToiletRecordClientImpl implements ToiletRecordClient {
 
   private final ToiletRecordQueryService toiletRecordQueryService;
+  private final ToiletReportMapper toiletReportMapper;
 
   @Override
   public List<DailyExistence> getDailyExistencesBetween(
@@ -25,5 +28,12 @@ public class ToiletRecordClientImpl implements ToiletRecordClient {
   @Override
   public int getToiletRecordCountByActivityAt(Long userId, ActivityAt activityAt) {
     return toiletRecordQueryService.countByActivityAt(userId, activityAt);
+  }
+
+  @Override
+  public HeroAssets getToiletHeroAssets(int score) {
+    var level = ToiletEvaluationLevel.from(score);
+    var assets = toiletReportMapper.heroAssetsByLevel(level);
+    return new HeroAssets(assets.image(), assets.backgroundColors());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
@@ -15,12 +15,16 @@ import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto;
 import depromeet.lessonfour.server.report.api.mapper.DailyReportMapper;
 import depromeet.lessonfour.server.report.api.mapper.MonthlyReportMapper;
+import depromeet.lessonfour.server.report.api.mapper.WeeklyReportMapper;
 import depromeet.lessonfour.server.report.app.dto.response.DailyReport;
 import depromeet.lessonfour.server.report.app.dto.response.MonthlyReport;
+import depromeet.lessonfour.server.report.app.dto.response.WeeklyReport;
 import depromeet.lessonfour.server.report.app.service.GetDailyReportUseCase;
 import depromeet.lessonfour.server.report.app.service.MonthlyReportUseCase;
+import depromeet.lessonfour.server.report.app.service.WeeklyReportUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,8 +36,10 @@ import lombok.RequiredArgsConstructor;
 public class ReportController {
 
   private final GetDailyReportUseCase getDailyReportUseCase;
+  private final WeeklyReportUseCase weeklyReportUseCase;
   private final MonthlyReportUseCase monthlyReportUseCase;
   private final DailyReportMapper dailyReportMapper;
+  private final WeeklyReportMapper weeklyReportMapper;
   private final MonthlyReportMapper monthlyReportMapper;
   private final Clock clock;
 
@@ -46,6 +52,17 @@ public class ReportController {
     DailyReport dailyReport = getDailyReportUseCase.getDailyReport(userId, baseDateTime);
     return SuccessResponse.of(
         SuccessCode.SUCCESS_FETCH, dailyReportMapper.map(dailyReport, baseDateTime));
+  }
+
+  @Operation(summary = "주간 리포트 조회", description = "특정 주의 주간 리포트를 조회합니다.")
+  @GetMapping("/weekly")
+  public SuccessResponse<GetWeeklyReportResponseDto> getWeeklyReport(
+      @AuthenticationPrincipal(expression = "id") Long userId,
+      @RequestParam(required = false) LocalDateTime dateTime) {
+    LocalDateTime baseDateTime = (dateTime != null) ? dateTime : LocalDateTime.now(clock);
+    WeeklyReport weeklyReport = weeklyReportUseCase.generateWeeklyReport(userId, baseDateTime);
+    return SuccessResponse.of(
+        SuccessCode.SUCCESS_FETCH, weeklyReportMapper.map(weeklyReport, baseDateTime));
   }
 
   @Operation(summary = "월간 리포트 조회", description = "특정 달의 월간 리포트를 조회합니다.")

--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetMonthlyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetMonthlyReportResponseDto.java
@@ -2,49 +2,109 @@ package depromeet.lessonfour.server.report.api.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import depromeet.lessonfour.server.report.app.dto.response.MonthlyScore;
 import depromeet.lessonfour.server.report.app.dto.response.ToiletColorCount;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistribution;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
 
 public record GetMonthlyReportResponseDto(
-    MonthlyRecordCount recordCount,
+    MonthlyRecordCount monthlyRecordCounts,
+    List<Integer> monthlyDefecationScore,
+    UserAverage userAverage,
     MonthlyScore monthlyScore,
-    List<MonthlyToiletShape> shape,
+    ToiletShapeSection shape,
     MonthlyToiletTime timeDistribution,
     MonthlyToiletColor color,
     MonthlyToiletPain pain,
-    List<MonthlyToiletPeriod> timeOfDay) {
+    TimeOfDaySection timeOfDay,
+    FoodSection food,
+    WaterSection water,
+    StressSection stress,
+    SuggestionSection suggestion) {
 
+  // ====== 공통 상단 ======
   public record MonthlyRecordCount(
       int totalRecordCounts, int defecationRecordCounts, int lifestyleRecordCounts) {}
 
-  public record MonthlyToiletShape(String shape, int count, String message) {}
+  public record UserAverage(double me, double average, double topPercent, String titleMessage) {}
 
-  public record MonthlyToiletTime(int within5min, int over5min, int over10min) {
+  // ====== shape ======
+  public record ToiletShapeSection(String titleMessage, List<MonthlyToiletShape> items) {}
 
-    public static MonthlyToiletTime from(ToiletTimeDistribution toiletTimeDistribution) {
+  public record MonthlyToiletShape(
+      String shape, int count, @JsonProperty("warning") String message) {}
+
+  // ====== timeDistribution ======
+  public record MonthlyToiletTime(
+      int within5min, int over5min, int over10min, String titleMessage) {
+    public static MonthlyToiletTime from(
+        ToiletTimeDistribution toiletTimeDistribution, String titleMessage) {
       return new MonthlyToiletTime(
           toiletTimeDistribution.within5min(),
           toiletTimeDistribution.over5min(),
-          toiletTimeDistribution.over10min());
+          toiletTimeDistribution.over10min(),
+          titleMessage);
     }
   }
 
-  public record MonthlyToiletColor(List<ColorCount> items, String colorMessage) {
+  // ====== color ======
+  public record MonthlyToiletColor(
+      List<ColorCount> items, String colorMessage, String titleMessage) {
 
-    public record ColorCount(String color, int count) {
+    public record ColorCount(String color, int count, String warning) {
 
       public static ColorCount from(ToiletColorCount toiletColorCount) {
-        return new ColorCount(toiletColorCount.color().getValue(), toiletColorCount.count());
+        return new ColorCount(
+            toiletColorCount.color().getValue(),
+            toiletColorCount.count(),
+            toiletColorCount.color().equals(ToiletColor.RED) ? "전문가 상담 권장" : null);
       }
     }
   }
 
+  // ====== pain ======
   public record MonthlyToiletPain(
-      int veryLow, int low, int medium, int high, int veryHigh, ToiletPainComparison comparison) {
+      String titleMessage,
+      int veryLow,
+      int low,
+      int medium,
+      int high,
+      int veryHigh,
+      ToiletPainComparison comparison) {
 
     public record ToiletPainComparison(String direction, int count) {}
   }
 
+  // ====== timeOfDay ======
+  public record TimeOfDaySection(String titleMessage, List<MonthlyToiletPeriod> items) {}
+
   public record MonthlyToiletPeriod(String period, int count) {}
+
+  // ====== food ======
+  public record FoodSection(
+      String message, MonthlyComparison monthlyComparison, List<WeeklyGroup> weeklyGroups) {
+    public record MonthlyComparison(int lastMonth, int thisMonth) {}
+
+    public record WeeklyGroup(
+        String weekLabel, String startDate, String endDate, List<FoodItem> items) {
+      public record FoodItem(String occurredAt, String mealTime, List<String> foods) {}
+    }
+  }
+
+  // ====== water ======
+  public record WaterSection(String message, List<WaterItem> items) {
+    public record WaterItem(String name, double value) {}
+  }
+
+  // ====== stress ======
+  public record StressSection(String message, String image, List<StressItem> items) {
+    public record StressItem(String day, String stress) {}
+  }
+
+  // ====== suggestion ======
+  public record SuggestionSection(String message, List<SuggestionItem> items) {
+    public record SuggestionItem(String image, String title, String content) {}
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetWeeklyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetWeeklyReportResponseDto.java
@@ -1,0 +1,38 @@
+package depromeet.lessonfour.server.report.api.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetWeeklyReportResponseDto(
+    LocalDateTime updatedAt,
+    DefecationScore defecationScore,
+    UserAverage userAverage,
+    FoodSection food,
+    WaterSection water,
+    StressSection stress,
+    SuggestionSection suggestion,
+    String externalLink) {
+
+  public record DefecationScore(double lastWeek, double thisWeek, List<Double> dailyScore) {}
+
+  public record UserAverage(double me, double average, double topPercent) {}
+
+  public record FoodSection(
+      String message, WeeklyComparison weeklyComparison, List<FoodItem> items) {
+    public record WeeklyComparison(int lastWeek, int thisWeek) {}
+
+    public record FoodItem(String occurredAt, String mealTime, List<String> foods) {}
+  }
+
+  public record WaterSection(String message, List<WaterItem> items) {
+    public record WaterItem(String name, double value) {}
+  }
+
+  public record StressSection(String message, String image, List<StressItem> items) {
+    public record StressItem(String day, String stress) {}
+  }
+
+  public record SuggestionSection(String message, List<SuggestionItem> items) {
+    public record SuggestionItem(String image, String title, String content) {}
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/MonthlyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/MonthlyReportMapper.java
@@ -1,34 +1,420 @@
 package depromeet.lessonfour.server.report.api.mapper;
 
+import static java.util.stream.Collectors.toList;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.FoodSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.FoodSection.MonthlyComparison;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.FoodSection.WeeklyGroup;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyRecordCount;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletColor;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletColor.ColorCount;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletPain;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletPain.ToiletPainComparison;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletPeriod;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletTime;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.TimeOfDaySection;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.ToiletShapeSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.UserAverage;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.WaterSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.WaterSection.WaterItem;
 import depromeet.lessonfour.server.report.app.dto.response.MonthlyReport;
 import depromeet.lessonfour.server.report.app.dto.response.RecordCounts;
+import depromeet.lessonfour.server.report.app.dto.response.ToiletColorCount;
+import depromeet.lessonfour.server.report.app.dto.response.ToiletShapeCount;
+import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.FoodEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.Suggestion;
+import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
+import depromeet.lessonfour.server.report.domain.vo.monthly.DayPeriod;
+import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPainDistribution;
+import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPeriodCount;
+import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistribution;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class MonthlyReportMapper {
 
-  private final ToiletReportMapper toiletReportMapper;
+  private final StressMapper stressMapper;
+  private final SuggestionMapper suggestionMapper;
 
-  public GetMonthlyReportResponseDto map(MonthlyReport monthlyReport) {
-
-    return new GetMonthlyReportResponseDto(
-        from(monthlyReport.recordCounts()),
-        monthlyReport.monthlyScore(),
-        toiletReportMapper.mapShape(monthlyReport.shape()),
-        MonthlyToiletTime.from(monthlyReport.timeDistribution()),
-        toiletReportMapper.mapColor(monthlyReport.color()),
-        toiletReportMapper.mapPain(monthlyReport.pain()),
-        toiletReportMapper.mapPeriod(monthlyReport.timeOfDay()));
+  // 컨트롤러 기본 사용
+  public GetMonthlyReportResponseDto map(MonthlyReport m) {
+    return internalMap(m, null);
   }
 
-  private static MonthlyRecordCount from(RecordCounts recordCounts) {
-    return new MonthlyRecordCount(
-        recordCounts.totalCount(), recordCounts.toiletCount(), recordCounts.activityCount());
+  // YearMonth까지 넘기고 싶을 때 사용
+  public GetMonthlyReportResponseDto map(MonthlyReport m, YearMonth month) {
+    return internalMap(m, month);
+  }
+
+  private GetMonthlyReportResponseDto internalMap(MonthlyReport m, YearMonth month) {
+    MonthlyRecordCount recordCount = mapRecordCount(m.recordCounts());
+    List<Integer> monthlyDefecationScore = safeList(m.weeklyAverageScores());
+    UserAverage userAverage = mapUserAverage(m.averageScore());
+    var monthlyScore = m.monthlyScore();
+
+    ToiletShapeSection shapeSection = mapShapeSection(m.shape());
+    MonthlyToiletTime timeSection = mapTimeDistribution(m.timeDistribution());
+    MonthlyToiletColor colorSection = mapColorSection(m.color());
+    MonthlyToiletPain painSection = mapPainSection(m.pain());
+    TimeOfDaySection timeOfDaySection = mapTimeOfDay(m.timeOfDay());
+
+    // 월간 Activity (주차 단위 → DTO 주차그룹으로 변환)
+    FoodSection foodSection = mapFoodSection(m.activityReport(), month);
+    WaterSection waterSection = mapWaterSection(m.activityReport());
+    var stressSection = mapStressSection(m.activityReport());
+
+    var suggestionDto = mapSuggestionSection(m.suggestion());
+
+    return new GetMonthlyReportResponseDto(
+        recordCount,
+        monthlyDefecationScore,
+        userAverage,
+        monthlyScore,
+        shapeSection,
+        timeSection,
+        colorSection,
+        painSection,
+        timeOfDaySection,
+        foodSection,
+        waterSection,
+        stressSection,
+        suggestionDto);
+  }
+
+  // ===== 상단 =====
+  private static MonthlyRecordCount mapRecordCount(RecordCounts rc) {
+    return new MonthlyRecordCount(rc.totalCount(), rc.toiletCount(), rc.activityCount());
+  }
+
+  private static UserAverage mapUserAverage(double myAverage) {
+    double overallAvg = myAverage; // 전체 평균 미정 → 우선 동일값
+    double topPercent = (myAverage >= 80) ? 20.0 : (myAverage >= 60) ? 50.0 : 80.0;
+    String title = String.format("이번 달 배변 점수는\n상위 %.0f%%예요", topPercent);
+    return new UserAverage(myAverage, overallAvg, topPercent, title);
+  }
+
+  // ===== 화장실 섹션 =====
+  private ToiletShapeSection mapShapeSection(List<ToiletShapeCount> shapes) {
+    String title = "이번 달 자주 본 배변 모양이에요";
+    List<GetMonthlyReportResponseDto.MonthlyToiletShape> items =
+        (shapes == null)
+            ? List.of()
+            : shapes.stream()
+                .sorted(Comparator.comparing(ToiletShapeCount::count).reversed())
+                .limit(3)
+                .map(
+                    sc ->
+                        new GetMonthlyReportResponseDto.MonthlyToiletShape(
+                            sc.shape().getValue(), sc.count(), warningByShape(sc.shape())))
+                .collect(toList());
+    return new ToiletShapeSection(title, items);
+  }
+
+  private static String warningByShape(ToiletShape shape) {
+    return switch (shape) {
+      case RABBIT -> "변비 주의";
+      case CORN -> "수분 충전 필요";
+      case CREAM, PORRIDGE, WATER -> "설사 주의";
+      default -> null;
+    };
+  }
+
+  private static MonthlyToiletTime mapTimeDistribution(ToiletTimeDistribution td) {
+    String title = "이번 달 배변 소요 시간을 살펴봤어요";
+    ToiletTimeDistribution safe = (td == null) ? new ToiletTimeDistribution(0, 0, 0) : td;
+    return MonthlyToiletTime.from(safe, title);
+  }
+
+  private MonthlyToiletColor mapColorSection(List<ToiletColorCount> colors) {
+    List<ColorCount> items =
+        (colors == null) ? List.of() : colors.stream().map(ColorCount::from).collect(toList());
+
+    String topLabel =
+        (items.isEmpty())
+            ? "없어요"
+            : items.stream()
+                .max(Comparator.comparingInt(ColorCount::count))
+                .map(ColorCount::color)
+                .orElse("없어요");
+
+    String title = "가장 많이 확인한 색상은\n" + topLabel + "예요";
+    String priorityMsg = topPriorityColorMessage(colors);
+
+    return new MonthlyToiletColor(items, priorityMsg, title);
+  }
+
+  private static String topPriorityColorMessage(List<ToiletColorCount> counts) {
+    if (counts == null || counts.isEmpty()) return null;
+    if (counts.stream().anyMatch(c -> c.color() == ToiletColor.RED && c.count() > 0))
+      return "혈변은 건강의 적신호예요. 대장염, 대장암, 치질 등의 문제일 수도 있어요. 빠른 병원 방문을 권장해요.";
+    if (counts.stream().anyMatch(c -> c.color() == ToiletColor.GRAY && c.count() > 0))
+      return "흰색은 건강의 적신호예요. 간이나 담도가 좋지 않은 상태일 수도 있어요. 빠른 병원 방문을 권장해요.";
+    if (counts.stream().anyMatch(c -> c.color() == ToiletColor.BLACK && c.count() > 0))
+      return "흑변은 건강의 적신호예요. 위궤양, 위암 등 위 관련 문제일 수도 있어요. 즉시 병원을 방문하셔야 해요.";
+    return null;
+  }
+
+  private static MonthlyToiletPain mapPainSection(ToiletPainDistribution pd) {
+    int painfulDays = (pd == null) ? 0 : pd.high() + pd.veryHigh();
+    String title = String.format("이번 달은 배를 부여잡은 날들이\n%d회 있었어요", painfulDays);
+
+    ToiletPainComparison diff =
+        (pd == null) ? new ToiletPainComparison("same", 0) : fromPainDiff(pd.painDiff());
+
+    return new MonthlyToiletPain(
+        title,
+        pd == null ? 0 : pd.veryLow(),
+        pd == null ? 0 : pd.low(),
+        pd == null ? 0 : pd.medium(),
+        pd == null ? 0 : pd.high(),
+        pd == null ? 0 : pd.veryHigh(),
+        diff);
+  }
+
+  private static ToiletPainComparison fromPainDiff(int d) {
+    if (d > 0) return new ToiletPainComparison("increased", d);
+    if (d < 0) return new ToiletPainComparison("decreased", -d);
+    return new ToiletPainComparison("same", 0);
+  }
+
+  private static TimeOfDaySection mapTimeOfDay(List<ToiletPeriodCount> counts) {
+    List<MonthlyToiletPeriod> items =
+        (counts == null)
+            ? List.of()
+            : counts.stream()
+                .map(pc -> new MonthlyToiletPeriod(pc.period().getValue(), pc.count()))
+                .collect(toList());
+
+    String best =
+        (counts == null || counts.isEmpty())
+            ? "오전"
+            : counts.stream()
+                .max(Comparator.comparingInt(ToiletPeriodCount::count))
+                .map(pc -> toKorean(pc.period()))
+                .orElse("오전");
+    String title = String.format("이번 달은 주로 %s에 성공했어요", best);
+
+    return new TimeOfDaySection(title, items);
+  }
+
+  private static String toKorean(DayPeriod p) {
+    return switch (p) {
+      case MORNING -> "오전";
+      case AFTERNOON -> "오후";
+      case EVENING -> "저녁";
+    };
+  }
+
+  // ===== 월간 Activity → DTO 변환 =====
+
+  private FoodSection mapFoodSection(MonthlyActivityReport ar, YearMonth month) {
+    if (ar == null || ar.weeklyGroups() == null || ar.weeklyGroups().isEmpty()) {
+      return new FoodSection(
+          "음식 기록이 없어요. 장에 좋은 음식을 먹어볼까요?", new MonthlyComparison(0, 0), List.of());
+    }
+
+    List<WeeklyGroup> dtoGroups = new ArrayList<>();
+    for (MonthlyActivityReport.WeeklyGroup g : ar.weeklyGroups()) {
+      // (옵션) month 검증이 필요하면 여기서 YearMonth.from(start/end) 체크
+      dtoGroups.add(toDtoWeeklyFoodGroup(g));
+    }
+
+    int lastMonthDangerous = ar.lastMonthDangerousDays();
+    int thisMonthDangerous = ar.dangerousFoodDays();
+
+    String message =
+        (thisMonthDangerous >= 10)
+            ? "자극적인 음식을 10회 이상 섭취했어요\n식단 관리가 필요해요!"
+            : (thisMonthDangerous > 0)
+                ? "자극적인 음식을 10회 미만으로 섭취했어요.\n지속적으로 줄여나가요!"
+                : "건강한 식단을\n열심히 유지하고 계시네요!";
+
+    return new FoodSection(
+        message, new MonthlyComparison(lastMonthDangerous, thisMonthDangerous), dtoGroups);
+  }
+
+  private WeeklyGroup toDtoWeeklyFoodGroup(MonthlyActivityReport.WeeklyGroup g) {
+    String weekLabel = g.weekIndex() + "주차";
+    LocalDate start = g.startDate();
+    LocalDate end = g.endDate();
+
+    List<GetMonthlyReportResponseDto.FoodSection.WeeklyGroup.FoodItem> items = new ArrayList<>();
+
+    int dayIdx = 0;
+    for (DailyActivityReport daily : safeList(g.dailyReports())) {
+      // DailyActivityReport에는 날짜가 없으니 주차 시작일 + dayIdx로 보정
+      LocalDate date = start.plusDays(dayIdx);
+
+      for (FoodEvaluation fe : safeList(daily.getFoodEvaluations())) {
+        fe.getFoodsByMealTime()
+            .forEach(
+                (mealTime, foods) -> {
+                  if (foods != null && !foods.isEmpty()) {
+                    items.add(
+                        new GetMonthlyReportResponseDto.FoodSection.WeeklyGroup.FoodItem(
+                            date.toString(), // occurredAt = 실제 일자
+                            mealTime.name(), // 조식/중식/석식 등 enum 이름
+                            foods));
+                  }
+                });
+      }
+      dayIdx++;
+      if (date.isAfter(end)) break; // 안전장치: 주차 범위 초과 방지(선택)
+    }
+
+    return new GetMonthlyReportResponseDto.FoodSection.WeeklyGroup(
+        weekLabel, start.toString(), end.toString(), items);
+  }
+
+  private WaterSection mapWaterSection(MonthlyActivityReport ar) {
+    if (ar == null || ar.weeklyGroups() == null || ar.weeklyGroups().isEmpty()) {
+      return new WaterSection("물 섭취 기록이 없어요\n물을 자주 마셔주세요", List.of());
+    }
+
+    List<WaterItem> items = new ArrayList<>();
+    double highValue = 2000.0, mediumValue = 1200.0, lowValue = 600.0;
+
+    List<WaterLevel> weekLevels = new ArrayList<>();
+    for (MonthlyActivityReport.WeeklyGroup g : ar.weeklyGroups()) {
+      WaterLevel weekLevel = aggregateWeeklyWaterLevel(g); // 일별 레벨 평균(반올림)
+      weekLevels.add(weekLevel);
+
+      double value =
+          switch (weekLevel) {
+            case HIGH -> highValue;
+            case MEDIUM -> mediumValue;
+            case LOW -> lowValue;
+            case NONE -> 0.0;
+          };
+      items.add(new WaterItem(g.weekIndex() + "주차", value));
+    }
+
+    // 월 레벨 = NONE 제외 주차 레벨들의 ordinal 평균(반올림)
+    int sum = 0, cnt = 0;
+    for (WaterLevel wl : weekLevels) {
+      if (wl != WaterLevel.NONE) {
+        sum += wl.ordinal();
+        cnt++;
+      }
+    }
+    WaterLevel monthLevel;
+    if (cnt == 0) {
+      monthLevel = WaterLevel.NONE;
+    } else {
+      int avgOrdinal = Math.round((float) sum / cnt);
+      WaterLevel[] lvls = WaterLevel.values();
+      // 안전 클램프
+      avgOrdinal = Math.min(Math.max(avgOrdinal, 0), lvls.length - 1);
+      monthLevel = lvls[avgOrdinal];
+    }
+
+    String message =
+        switch (monthLevel) {
+          case NONE -> "물 섭취 기록이 없어요\n물을 자주 마셔주세요";
+          case LOW -> "장이 말라가고 있어요!\n물 섭취량을 늘려야 해요";
+          case MEDIUM, HIGH -> "물을 잘 섭취하고 계시군요!\n앞으로도 잘 유지해봐요";
+        };
+
+    return new WaterSection(message, items);
+  }
+
+  private static WaterLevel aggregateWeeklyWaterLevel(MonthlyActivityReport.WeeklyGroup g) {
+    if (g.dailyReports() == null || g.dailyReports().isEmpty()) return WaterLevel.NONE;
+
+    int sumOrdinal = 0, cnt = 0;
+    for (DailyActivityReport d : g.dailyReports()) {
+      List<WaterEvaluation> ws = d.getWaterEvaluations();
+      if (ws != null && !ws.isEmpty()) {
+        WaterLevel lvl = ws.get(0).getLevel(); // 동일 기준 유지
+        sumOrdinal += lvl.ordinal();
+        cnt++;
+      }
+    }
+    if (cnt == 0) return WaterLevel.NONE;
+    int avgOrdinal = Math.round((float) sumOrdinal / cnt);
+    WaterLevel[] levels = WaterLevel.values();
+    return levels[Math.min(Math.max(avgOrdinal, 0), levels.length - 1)];
+  }
+
+  private GetMonthlyReportResponseDto.StressSection mapStressSection(MonthlyActivityReport ar) {
+    List<GetMonthlyReportResponseDto.StressSection.StressItem> items = new ArrayList<>();
+
+    if (ar == null || ar.weeklyGroups() == null || ar.weeklyGroups().isEmpty()) {
+      return new GetMonthlyReportResponseDto.StressSection(
+          "스트레스 기록이 없어요\n마음 편한 한 달이었네요!",
+          "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png",
+          items);
+    }
+
+    StressEvaluation monthWorst = StressEvaluation.NONE;
+
+    for (MonthlyActivityReport.WeeklyGroup g : ar.weeklyGroups()) {
+      // 주차 최악: NONE 제외 후 min(ordinal)
+      StressEvaluation weekWorst =
+          (g.dailyReports() == null
+              ? null
+              : g.dailyReports().stream()
+                  .map(DailyActivityReport::getStressEvaluation)
+                  .filter(s -> s != null && s != StressEvaluation.NONE)
+                  .min(Comparator.comparingInt(Enum::ordinal))
+                  .orElse(null));
+
+      if (weekWorst == null) weekWorst = StressEvaluation.NONE;
+
+      items.add(
+          new GetMonthlyReportResponseDto.StressSection.StressItem(
+              g.weekIndex() + "주차", weekWorst.name()));
+
+      // 월 최악 갱신 (NONE 제외, 더 낮은 ordinal일수록 더 ‘나쁨’)
+      if (weekWorst != StressEvaluation.NONE) {
+        if (monthWorst == StressEvaluation.NONE || weekWorst.ordinal() < monthWorst.ordinal()) {
+          monthWorst = weekWorst;
+        }
+      }
+    }
+
+    GetDailyReportResponseDto.StressReport base = stressMapper.map(monthWorst);
+    if (base == null) {
+      base =
+          new GetDailyReportResponseDto.StressReport(
+              "스트레스 기록이 없어요\n마음 편한 한 달이었네요!",
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
+    }
+
+    return new GetMonthlyReportResponseDto.StressSection(base.message(), base.image(), items);
+  }
+
+  private GetMonthlyReportResponseDto.SuggestionSection mapSuggestionSection(
+      Suggestion suggestion) {
+    var dto = suggestionMapper.map(suggestion);
+    var items =
+        dto.items().stream()
+            .map(
+                i ->
+                    new GetMonthlyReportResponseDto.SuggestionSection.SuggestionItem(
+                        i.image(), i.title(), i.content()))
+            .toList();
+    return new GetMonthlyReportResponseDto.SuggestionSection(dto.message(), items);
+  }
+
+  private static <T> List<T> safeList(List<T> in) {
+    return (in == null) ? List.of() : in;
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/StressMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/StressMapper.java
@@ -9,10 +9,8 @@ import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
 public class StressMapper {
 
   public StressReport map(StressEvaluation stressEvaluation) {
-    if (stressEvaluation == null || stressEvaluation == StressEvaluation.NONE) {
-      return new StressReport(
-          "스트레스 기록이 없어요\n마음 편한 하루였네요!",
-          "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
+    if (stressEvaluation == null) {
+      return null;
     }
 
     return switch (stressEvaluation) {
@@ -31,7 +29,7 @@ public class StressMapper {
       case VERY_HIGH -> new StressReport(
           "스트레스 Zero! 행복한 하루가 되셨군요?",
           "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_very_good.png");
-      case NONE -> throw new IllegalStateException("unreachable");
+      case NONE -> null;
     };
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/StressMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/StressMapper.java
@@ -9,6 +9,12 @@ import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
 public class StressMapper {
 
   public StressReport map(StressEvaluation stressEvaluation) {
+    if (stressEvaluation == null || stressEvaluation == StressEvaluation.NONE) {
+      return new StressReport(
+          "스트레스 기록이 없어요\n마음 편한 하루였네요!",
+          "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
+    }
+
     return switch (stressEvaluation) {
       case VERY_LOW -> new StressReport(
           "삐용삐용! 스트레스 만땅! 산책이나 명상을 해볼까요?",
@@ -25,7 +31,7 @@ public class StressMapper {
       case VERY_HIGH -> new StressReport(
           "스트레스 Zero! 행복한 하루가 되셨군요?",
           "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_very_good.png");
-      case NONE -> null;
+      case NONE -> throw new IllegalStateException("unreachable");
     };
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/ToiletReportMapper.java
@@ -1,5 +1,6 @@
 package depromeet.lessonfour.server.report.api.mapper;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,13 @@ public class ToiletReportMapper {
   // 일간 리포트
   public DailyToiletReportResponse map(DailyToiletReport dailyToiletReport) {
     return DailyMapper.map(dailyToiletReport);
+  }
+
+  public record ToiletHeroAssets(String image, List<String> backgroundColors) {}
+
+  public ToiletHeroAssets heroAssetsByLevel(ToiletEvaluationLevel level) {
+    var hero = DailyMapper.lookupHero(level); // 내부 맵 재사용
+    return new ToiletHeroAssets(hero.image(), hero.backgroundColors());
   }
 
   // 월간 리포트
@@ -85,6 +93,15 @@ public class ToiletReportMapper {
                 "기분 좋은 대장",
                 "장 컨디션 아주 굿!",
                 List.of("#0C7C30", "#7DD357")));
+
+    // 내부 맵을 안전하게 노출하는 조회 함수 (NONE/NULL 폴백 포함)
+    static HeroCharacter lookupHero(ToiletEvaluationLevel level) {
+      ToiletEvaluationLevel safeLevel =
+          (level == null || level == ToiletEvaluationLevel.NONE)
+              ? ToiletEvaluationLevel.AVERAGE
+              : level;
+      return characterMap.getOrDefault(safeLevel, characterMap.get(ToiletEvaluationLevel.AVERAGE));
+    }
 
     private static final String message =
         "전문가의 상담이 필요해요. 복통이 매우 심했다면 단순한 식사 문제를 넘어서 장염이나 자극적인 음식으로 인한 장 트러블일 수 있습니다.";
@@ -149,16 +166,28 @@ public class ToiletReportMapper {
 
       List<ColorCount> items = safe.stream().map(ColorCount::from).toList();
 
-      String message =
+      // 경고 메시지 (RED / GRAY / BLACK 우선)
+      String colorMessage =
           PRIORITY.stream()
               .filter(
                   priorityColor ->
                       safe.stream().anyMatch(c -> c.color() == priorityColor && c.count() > 0))
               .map(MESSAGE_BY_COLOR::get)
               .findFirst()
-              .orElse(null); // 경고 색상이 없으면 메시지 없이
+              .orElse(null);
 
-      return new MonthlyToiletColor(items, message);
+      // 타이틀 메시지: 가장 많이 등장한 색상 기준
+      String titleMessage = null;
+      if (!safe.isEmpty()) {
+        ToiletColorCount top =
+            safe.stream()
+                .max(Comparator.comparingInt(ToiletColorCount::count))
+                .orElse(safe.getFirst());
+        // enum의 value 그대로 사용 (예: DARK_BROWN, GOLD 등)
+        titleMessage = "가장 많이 확인한 색상은\n" + top.color().getValue() + "이에요";
+      }
+
+      return new MonthlyToiletColor(items, colorMessage, titleMessage);
     }
 
     static ToiletPainComparison fromPainDiff(int painDiff) {
@@ -172,12 +201,23 @@ public class ToiletReportMapper {
     }
 
     static MonthlyToiletPain fromPain(ToiletPainDistribution toiletPainDistribution) {
+      int veryLow = toiletPainDistribution.veryLow();
+      int low = toiletPainDistribution.low();
+      int medium = toiletPainDistribution.medium();
+      int high = toiletPainDistribution.high();
+      int veryHigh = toiletPainDistribution.veryHigh();
+
+      int painfulDays = medium + high + veryHigh;
+
+      String titleMessage = "이번 달은 배를 부여잡은 날들이\n" + painfulDays + "회 있었어요";
+
       return new MonthlyToiletPain(
-          toiletPainDistribution.veryLow(),
-          toiletPainDistribution.low(),
-          toiletPainDistribution.medium(),
-          toiletPainDistribution.high(),
-          toiletPainDistribution.veryHigh(),
+          titleMessage,
+          veryLow,
+          low,
+          medium,
+          high,
+          veryHigh,
           fromPainDiff(toiletPainDistribution.painDiff()));
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
@@ -1,0 +1,248 @@
+package depromeet.lessonfour.server.report.api.mapper;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.DefecationScore;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.FoodSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.FoodSection.FoodItem;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.FoodSection.WeeklyComparison;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.StressSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.StressSection.StressItem;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.SuggestionSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.SuggestionSection.SuggestionItem;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.UserAverage;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.WaterSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportResponseDto.WaterSection.WaterItem;
+import depromeet.lessonfour.server.report.app.dto.response.WeeklyReport;
+import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.FoodEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.Suggestion;
+import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.WaterLevel;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyReportMapper {
+
+  private final StressMapper stressMapper;
+  private final SuggestionMapper suggestionMapper;
+
+  public GetWeeklyReportResponseDto map(WeeklyReport weeklyReport, LocalDateTime updatedAt) {
+
+    // updatedAt 기준 이번 주 월요일
+    LocalDate thisWeekStartDate = updatedAt.toLocalDate().with(DayOfWeek.MONDAY);
+
+    DefecationScore defecationScore =
+        new DefecationScore(
+            weeklyReport.lastWeekAverageScore(),
+            weeklyReport.thisWeekAverageScore(),
+            weeklyReport.dailyScores().stream().map(Double::valueOf).toList());
+
+    UserAverage userAverage = mapUserAverage(weeklyReport.thisWeekAverageScore());
+
+    FoodSection foodSection =
+        mapFoodSection(
+            weeklyReport.lastWeekActivity(), weeklyReport.thisWeekActivity(), thisWeekStartDate);
+
+    WaterSection waterSection = mapWaterSection(weeklyReport.thisWeekActivity());
+
+    StressSection stressSection = mapStressSection(weeklyReport.thisWeekActivity());
+
+    SuggestionSection suggestionSection = mapSuggestionSection(weeklyReport.suggestion());
+
+    // TODO: externalLink 은 일단 null 로 두고, 나중에 채우기
+    return new GetWeeklyReportResponseDto(
+        updatedAt,
+        defecationScore,
+        userAverage,
+        foodSection,
+        waterSection,
+        stressSection,
+        suggestionSection,
+        null);
+  }
+
+  private static UserAverage mapUserAverage(double thisWeekAverageScore) {
+    double me = thisWeekAverageScore;
+    double average = 60.0; // TODO: 실제 전체 평균으로 치환 예정
+    double topPercent;
+    if (me >= 80) {
+      topPercent = 20.0;
+    } else if (me >= 60) {
+      topPercent = 50.0;
+    } else {
+      topPercent = 80.0;
+    }
+    return new UserAverage(me, average, topPercent);
+  }
+
+  private static FoodSection mapFoodSection(
+      WeeklyActivityReport lastWeek, WeeklyActivityReport thisWeek, LocalDate thisWeekStartDate) {
+
+    int lastWeekDangerous = (int) lastWeek.dangerousFoodDays();
+    int thisWeekDangerous = (int) thisWeek.dangerousFoodDays();
+
+    String message;
+    if (thisWeekDangerous >= 10) {
+      message = "자극적인 음식을 10회 이상 섭취했어요\n식단 관리가 필요해요!";
+    } else if (thisWeekDangerous > 0) {
+      message = "자극적인 음식을 10회 미만으로 섭취했어요.\n지속적으로 줄여나가요!";
+    } else {
+      message = "건강한 식단을\n열심히 유지하고 계시네요!";
+    }
+
+    WeeklyComparison comparison = new WeeklyComparison(lastWeekDangerous, thisWeekDangerous);
+
+    // 주간 아이템: 이번 주 DailyActivityReport 기준으로 쭉 펼치기
+    List<FoodItem> items = new ArrayList<>();
+
+    int dayIndex = 0;
+    for (DailyActivityReport daily : thisWeek.getDailyReports()) {
+      LocalDate date = thisWeekStartDate.plusDays(dayIndex);
+      for (FoodEvaluation eval :
+          (daily.getFoodEvaluations() == null
+              ? List.<FoodEvaluation>of()
+              : daily.getFoodEvaluations())) {
+        eval.getFoodsByMealTime()
+            .forEach(
+                (mealTime, foods) -> {
+                  if (foods != null && !foods.isEmpty()) {
+                    items.add(new FoodItem(date.toString(), mealTime.name(), foods));
+                  }
+                });
+      }
+
+      dayIndex++;
+    }
+
+    return new FoodSection(message, comparison, items);
+  }
+
+  private static WaterSection mapWaterSection(WeeklyActivityReport thisWeek) {
+    // WaterLevel → 대략적인 ml 값
+    double highValue = 2000.0;
+    double mediumValue = 1200.0;
+    double lowValue = 600.0;
+
+    List<WaterItem> items = new ArrayList<>();
+
+    String[] dayNames = {
+      "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"
+    };
+
+    int idx = 0;
+    for (DailyActivityReport daily : thisWeek.getDailyReports()) {
+      WaterLevel level =
+          daily.getWaterEvaluations().isEmpty()
+              ? WaterLevel.NONE
+              : daily.getWaterEvaluations().get(0).getLevel();
+
+      double value =
+          switch (level) {
+            case HIGH -> highValue;
+            case MEDIUM -> mediumValue;
+            case LOW -> lowValue;
+            case NONE -> 0.0;
+          };
+
+      String name = idx < dayNames.length ? dayNames[idx] : "DAY_" + (idx + 1);
+      items.add(new WaterItem(name, value));
+      idx++;
+    }
+
+    // 메시지: 가장 높은 수준의 WaterLevel 기준
+    WaterLevel maxLevel = WaterLevel.NONE;
+    for (DailyActivityReport daily : thisWeek.getDailyReports()) {
+      for (WaterEvaluation eval : daily.getWaterEvaluations()) {
+        if (eval.getLevel().ordinal() > maxLevel.ordinal()) {
+          maxLevel = eval.getLevel();
+        }
+      }
+    }
+
+    String message;
+    if (thisWeek.getDailyReports().isEmpty() || maxLevel == WaterLevel.NONE) {
+      message = "물 섭취 기록이 없어요\n물을 자주 마셔주세요";
+    } else if (maxLevel == WaterLevel.LOW) {
+      message = "장이 말라가고 있어요!\n물 섭취량을 늘려야 해요";
+    } else {
+      message = "물을 잘 섭취하고 계시군요!\n앞으로도 잘 유지해봐요";
+    }
+
+    return new WaterSection(message, items);
+  }
+
+  private StressSection mapStressSection(WeeklyActivityReport thisWeek) {
+    // 1) 일단 items 리스트 만들고
+    List<StressItem> items = new ArrayList<>();
+
+    // 2) 아예 주간 활동이 없는 경우 (null or empty) → 기본 메시지 + 빈 리스트
+    if (thisWeek == null
+        || thisWeek.getDailyReports() == null
+        || thisWeek.getDailyReports().isEmpty()) {
+
+      return new StressSection(
+          "스트레스 기록이 없어요\n마음 편한 한 주였네요!",
+          "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png",
+          items);
+    }
+
+    // 3) 주간 최악 스트레스 레벨 계산
+    StressEvaluation worst =
+        thisWeek.getDailyReports().stream()
+            .map(DailyActivityReport::getStressEvaluation)
+            .filter(s -> s != null && s != StressEvaluation.NONE)
+            .min(Comparator.comparingInt(Enum::ordinal))
+            .orElse(StressEvaluation.NONE);
+
+    // 4) 기존 StressMapper 사용하되, null 이면 기본값으로 보정
+    GetDailyReportResponseDto.StressReport base = stressMapper.map(worst);
+
+    if (base == null) {
+      // NONE 등에 대해 StressMapper가 null을 주는 경우를 위한 안전장치
+      base =
+          new GetDailyReportResponseDto.StressReport(
+              "스트레스 기록이 없어요\n마음 편한 한 주였네요!",
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
+    }
+
+    // 5) 일별 아이템 생성 (요일 라벨은 원하는 대로)
+    String[] dayNames = {
+      "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"
+    };
+
+    int idx = 0;
+    for (DailyActivityReport daily : thisWeek.getDailyReports()) {
+      String day = idx < dayNames.length ? dayNames[idx] : "DAY_" + (idx + 1);
+      items.add(new StressItem(day, daily.getStressEvaluation().name()));
+      idx++;
+    }
+
+    // 6) 최종 섹션 반환
+    return new StressSection(base.message(), base.image(), items);
+  }
+
+  private SuggestionSection mapSuggestionSection(Suggestion suggestion) {
+    // 기존 SuggestionMapper → Daily용 DTO를 Weekly용으로 재래핑
+    var dto = suggestionMapper.map(suggestion);
+
+    List<SuggestionItem> items =
+        dto.items().stream()
+            .map(i -> new SuggestionItem(i.image(), i.title(), i.content()))
+            .toList();
+
+    return new SuggestionSection(dto.message(), items);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
@@ -204,6 +204,8 @@ public class WeeklyReportMapper {
         thisWeek.getDailyReports().stream()
             .map(DailyActivityReport::getStressEvaluation)
             .filter(s -> s != null && s != StressEvaluation.NONE)
+            // NOTE: enum 선언이 VERY_LOW(최악) → ... → VERY_HIGH(최상), NONE(제외)
+            // 낮을수록(ordinal 작을수록) 더 나쁜 상태이므로 min이 "최악"을 의미한다.
             .min(Comparator.comparingInt(Enum::ordinal))
             .orElse(StressEvaluation.NONE);
 
@@ -226,7 +228,9 @@ public class WeeklyReportMapper {
     int idx = 0;
     for (DailyActivityReport daily : thisWeek.getDailyReports()) {
       String day = idx < dayNames.length ? dayNames[idx] : "DAY_" + (idx + 1);
-      items.add(new StressItem(day, daily.getStressEvaluation().name()));
+      StressEvaluation ev = daily.getStressEvaluation();
+      String label = (ev == null ? StressEvaluation.NONE : ev).name(); // NULL-SAFE
+      items.add(new StressItem(day, label));
       idx++;
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/app/dto/response/MonthlyReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/dto/response/MonthlyReport.java
@@ -3,6 +3,7 @@ package depromeet.lessonfour.server.report.app.dto.response;
 import java.util.List;
 
 import depromeet.lessonfour.server.report.domain.vo.Suggestion;
+import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPainDistribution;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPeriodCount;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistribution;
@@ -10,9 +11,13 @@ import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistributi
 public record MonthlyReport(
     RecordCounts recordCounts,
     MonthlyScore monthlyScore,
+    double averageScore,
+    List<Integer> weeklyAverageScores,
     List<ToiletShapeCount> shape,
     ToiletTimeDistribution timeDistribution,
     List<ToiletColorCount> color,
     ToiletPainDistribution pain,
     List<ToiletPeriodCount> timeOfDay,
-    Suggestion suggestion) {}
+    Suggestion suggestion,
+    // 월간 Activity 원본 (주차 그룹 포함)
+    MonthlyActivityReport activityReport) {}

--- a/src/main/java/depromeet/lessonfour/server/report/app/dto/response/WeeklyReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/dto/response/WeeklyReport.java
@@ -1,0 +1,15 @@
+package depromeet.lessonfour.server.report.app.dto.response;
+
+import java.util.List;
+
+import depromeet.lessonfour.server.report.domain.vo.Suggestion;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
+
+public record WeeklyReport(
+    double lastWeekAverageScore,
+    double thisWeekAverageScore,
+    List<Integer> dailyScores, // 이번 주 월~일 점수
+    WeeklyActivityReport lastWeekActivity, // 지난 주 액티비티 요약
+    WeeklyActivityReport thisWeekActivity, // 이번 주 액티비티 요약
+    Suggestion suggestion // 주간 습관 제안
+    ) {}

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ActivityReportService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ActivityReportService.java
@@ -13,6 +13,7 @@ import depromeet.lessonfour.server.report.app.client.ActivityRecordClient;
 import depromeet.lessonfour.server.report.domain.service.ActivityEvaluationService;
 import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -34,11 +35,24 @@ public class ActivityReportService {
     return activityEvaluationService.evaluate(previousRecord, currentRecord);
   }
 
-  // TODO : 다른 통계치 추가하기
-  public MonthlyActivityReport generateMonthlyReport(
+  public WeeklyActivityReport generateWeeklyReport(
       Long userId, ActivityAt startAt, ActivityAt endAt) {
     List<ActivityRecord> records =
         activityRecordClient.getActivityRecordsBetween(userId, startAt, endAt);
-    return MonthlyActivityReport.dummy();
+    return activityEvaluationService.evaluateWeekly(records);
+  }
+
+  public MonthlyActivityReport generateMonthlyReport(
+      Long userId, ActivityAt startAt, ActivityAt endAt) {
+    List<ActivityRecord> current =
+        activityRecordClient.getActivityRecordsBetween(userId, startAt, endAt);
+    ActivityAt lastMonthStart = startAt.getLastMonth();
+    List<ActivityRecord> last =
+        activityRecordClient.getActivityRecordsBetween(userId, lastMonthStart, startAt);
+
+    LocalDate monthFirstDay = startAt.toDate();
+    LocalDate monthLastDay = endAt.toDate().minusDays(1);
+
+    return activityEvaluationService.evaluateMonthly(current, last, monthFirstDay, monthLastDay);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/MonthlyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/MonthlyReportUseCase.java
@@ -23,6 +23,7 @@ public class MonthlyReportUseCase {
   private final ToiletReportService toiletReportService;
   private final ActivityReportService activityReportService;
   private final SuggestionService suggestionService;
+  private final ToiletScoreService toiletScoreService;
 
   public MonthlyReport generateMonthlyReport(Long userId, YearMonth month) {
     ActivityAt monthStart = ActivityAt.of(month.atDay(1));
@@ -34,16 +35,23 @@ public class MonthlyReportUseCase {
     MonthlyActivityReport activityReport =
         activityReportService.generateMonthlyReport(userId, monthStart, monthEndExclusive);
 
+    // 월간 배변 점수 통계 (전체 평균 + 주차별 평균)
+    ToiletScoreService.MonthlyScoreStats scoreStats =
+        toiletScoreService.getMonthlyScoreStats(userId, monthStart, monthEndExclusive);
+
     Suggestion suggestion = suggestionService.suggest(activityReport, toiletReport);
 
     return new MonthlyReport(
         RecordCounts.of(activityReport.size(), toiletReport.size()),
         MonthlyScore.from(toiletReport.scoreSummary()),
+        scoreStats.averageScore(),
+        scoreStats.weeklyAverageScores(),
         toiletReport.shapeCount(),
         toiletReport.timeDistribution(),
         toiletReport.colorCount(),
         toiletReport.painDistribution(),
         toiletReport.periodCount(),
-        suggestion);
+        suggestion,
+        activityReport);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
@@ -1,5 +1,6 @@
 package depromeet.lessonfour.server.report.app.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,7 @@ import depromeet.lessonfour.server.report.domain.vo.monthly.ScoreSummary;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPainDistribution;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPeriodCount;
 import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistribution;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyToiletReport;
 import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
@@ -40,6 +42,26 @@ public class ToiletReportService {
         userId, (int) report.getToiletScore(), ActivityAt.from(baseDateTime));
 
     return report;
+  }
+
+  public WeeklyToiletReport generateWeeklyReport(
+      Long userId, ActivityAt start, ActivityAt endExclusive) {
+
+    // 일단 [start, end) 범위의 전체 기록 가져오기
+    List<ToiletRecord> records =
+        toiletRecordClient.getToiletRecordsByActivityAtBetween(userId, start, endExclusive);
+
+    // 날짜 기준으로 groupBy 해서 일별로 DailyToiletReport 생성
+    Map<LocalDate, List<ToiletRecord>> recordsByDate =
+        records.stream().collect(Collectors.groupingBy(r -> r.getActivityAt().toDate()));
+
+    List<DailyToiletReport> dailyReports =
+        recordsByDate.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey()) // 날짜 오름차순
+            .map(entry -> toiletEvaluationService.summarize(entry.getValue()))
+            .toList();
+
+    return new WeeklyToiletReport(dailyReports);
   }
 
   public MonthlyToiletReport generateMonthlyReport(

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreService.java
@@ -1,7 +1,12 @@
 package depromeet.lessonfour.server.report.app.service;
 
 import java.time.LocalDate;
+import java.util.IntSummaryStatistics;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,4 +46,49 @@ public class ToiletScoreService {
             existing -> existing.updateScore(score),
             () -> toiletScoreRepository.save(ToiletScore.of(userId, score, date)));
   }
+
+  // 월간 배변 점수 통계: 전체 평균 + 1~5주차 평균 리스트
+  @Transactional(readOnly = true)
+  public MonthlyScoreStats getMonthlyScoreStats(Long userId, ActivityAt start, ActivityAt end) {
+    List<ToiletScore> scores = toiletScoreRepository.findAllBetween(userId, start, end);
+
+    if (scores.isEmpty()) {
+      // 평균 0, 주차별 0으로 채운 5칸
+      List<Integer> weeklyZeros = IntStream.rangeClosed(1, 5).map(i -> 0).boxed().toList();
+      return new MonthlyScoreStats(0.0, weeklyZeros);
+    }
+
+    // 전체 평균
+    double average = scores.stream().mapToInt(ToiletScore::getScore).average().orElse(0.0);
+
+    // 날짜 → 주차 인덱스(1~5)
+    Map<Integer, List<ToiletScore>> scoresByWeek =
+        scores.stream()
+            .collect(
+                Collectors.groupingBy(
+                    s -> {
+                      LocalDate date = s.getDate();
+                      int dayOfMonth = date.getDayOfMonth();
+                      return ((dayOfMonth - 1) / 7) + 1; // 1~5주차
+                    }));
+
+    // 1~5주차 평균 점수, 비어있으면 0
+    List<Integer> weeklyAverageScores =
+        IntStream.rangeClosed(1, 5)
+            .mapToObj(
+                week -> {
+                  List<ToiletScore> weekScores = scoresByWeek.getOrDefault(week, List.of());
+                  if (weekScores.isEmpty()) {
+                    return 0;
+                  }
+                  IntSummaryStatistics stats =
+                      weekScores.stream().mapToInt(ToiletScore::getScore).summaryStatistics();
+                  return (int) Math.round(stats.getAverage());
+                })
+            .toList();
+
+    return new MonthlyScoreStats(average, weeklyAverageScores);
+  }
+
+  public record MonthlyScoreStats(double averageScore, List<Integer> weeklyAverageScores) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
@@ -1,0 +1,93 @@
+package depromeet.lessonfour.server.report.app.service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.report.app.dto.response.WeeklyReport;
+import depromeet.lessonfour.server.report.domain.service.SuggestionService;
+import depromeet.lessonfour.server.report.domain.vo.Suggestion;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyToiletReport;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class WeeklyReportUseCase {
+
+  private final ToiletReportService toiletReportService;
+  private final ActivityReportService activityReportService;
+  private final ToiletScoreService toiletScoreService;
+  private final SuggestionService suggestionService;
+
+  public WeeklyReport generateWeeklyReport(Long userId, LocalDateTime baseDateTime) {
+    LocalDate baseDate = baseDateTime.toLocalDate();
+
+    // 이번 주: 월요일 ~ 다음 주 월요일 직전까지 [start, end)
+    LocalDate thisWeekStartDate = baseDate.with(DayOfWeek.MONDAY);
+    LocalDate thisWeekEndExclusiveDate = thisWeekStartDate.plusDays(7);
+
+    // 지난 주: 이번 주 시작 -7일 ~ 이번 주 시작 [start, end)
+    LocalDate lastWeekStartDate = thisWeekStartDate.minusWeeks(1);
+    LocalDate lastWeekEndExclusiveDate = thisWeekStartDate;
+
+    ActivityAt thisWeekStart = ActivityAt.of(thisWeekStartDate);
+    ActivityAt thisWeekEndExclusive = ActivityAt.of(thisWeekEndExclusiveDate);
+
+    ActivityAt lastWeekStart = ActivityAt.of(lastWeekStartDate);
+    ActivityAt lastWeekEndExclusive = ActivityAt.of(lastWeekEndExclusiveDate);
+
+    // 주간 활동 리포트
+    WeeklyActivityReport thisWeekActivity =
+        activityReportService.generateWeeklyReport(userId, thisWeekStart, thisWeekEndExclusive);
+
+    WeeklyActivityReport lastWeekActivity =
+        activityReportService.generateWeeklyReport(userId, lastWeekStart, lastWeekEndExclusive);
+
+    // 주간 배변 리포트 (DailyToiletReport 7개 기반 WeeklyToiletReport)
+    WeeklyToiletReport thisWeekToilet =
+        toiletReportService.generateWeeklyReport(userId, thisWeekStart, thisWeekEndExclusive);
+
+    // 이번 주 점수 (월~일)
+    List<Integer> thisWeekDailyScores =
+        IntStream.range(0, 7)
+            .mapToObj(
+                i ->
+                    toiletScoreService.getScoreByActivityAt(
+                        userId, ActivityAt.of(thisWeekStartDate.plusDays(i))))
+            .toList();
+
+    double thisWeekAverageScore =
+        thisWeekDailyScores.stream().mapToInt(Integer::intValue).average().orElse(0.0);
+
+    // 지난 주 평균 점수
+    List<Integer> lastWeekDailyScores =
+        IntStream.range(0, 7)
+            .mapToObj(
+                i ->
+                    toiletScoreService.getScoreByActivityAt(
+                        userId, ActivityAt.of(lastWeekStartDate.plusDays(i))))
+            .toList();
+
+    double lastWeekAverageScore =
+        lastWeekDailyScores.stream().mapToInt(Integer::intValue).average().orElse(0.0);
+
+    // 주간 기준 습관 추천 (대표 하루 X, 주간 평균/횟수 기반)
+    Suggestion suggestion = suggestionService.suggest(thisWeekActivity, thisWeekToilet);
+
+    return new WeeklyReport(
+        lastWeekAverageScore,
+        thisWeekAverageScore,
+        thisWeekDailyScores,
+        lastWeekActivity,
+        thisWeekActivity,
+        suggestion);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/FoodEvaluationPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/FoodEvaluationPolicy.java
@@ -18,29 +18,39 @@ public class FoodEvaluationPolicy {
   private static final int DEFAULT_DANGEROUS_THRESHOLD = 80;
 
   public FoodEvaluation calculate(List<FoodRecord> records, DayType dayType) {
-    boolean dangerous = isDangerousExists(records);
+    if (records == null || records.isEmpty()) {
+      return new FoodEvaluation(false, Map.of(), dayType, Set.of());
+    }
 
+    // 1) 위험 음식 존재 여부
+    boolean dangerous =
+        records.stream()
+            .filter(r -> r != null && r.getFood() != null)
+            .anyMatch(r -> r.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD));
+
+    // 2) 식사시간별 음식 이름 리스트
     Map<MealTime, List<String>> foodsByMealTime =
         records.stream()
+            .filter(
+                r ->
+                    r != null
+                        && r.getMealTime() != null
+                        && r.getFood() != null
+                        && r.getFood().getName() != null)
             .collect(
                 Collectors.groupingBy(
                     FoodRecord::getMealTime,
-                    Collectors.mapping(record -> record.getFood().getName(), Collectors.toList())));
+                    () -> new java.util.EnumMap<>(MealTime.class),
+                    Collectors.mapping(r -> r.getFood().getName(), Collectors.toList())));
 
-    Set<MealTime> dangerousMealTimes = getDangerousMealTimes(records);
+    // 3) 위험 음식이 있었던 식사시간 집합
+    Set<MealTime> dangerousMealTimes =
+        records.stream()
+            .filter(r -> r != null && r.getMealTime() != null && r.getFood() != null)
+            .filter(r -> r.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD))
+            .map(FoodRecord::getMealTime)
+            .collect(Collectors.toSet());
 
     return new FoodEvaluation(dangerous, foodsByMealTime, dayType, dangerousMealTimes);
-  }
-
-  private static boolean isDangerousExists(List<FoodRecord> records) {
-    return records.stream()
-        .anyMatch(record -> record.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD));
-  }
-
-  private static Set<MealTime> getDangerousMealTimes(List<FoodRecord> records) {
-    return records.stream()
-        .filter(record -> record.getFood().isDangerous(DEFAULT_DANGEROUS_THRESHOLD))
-        .map(FoodRecord::getMealTime)
-        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/MonthlyToiletStats.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/MonthlyToiletStats.java
@@ -1,0 +1,81 @@
+package depromeet.lessonfour.server.report.domain.policy;
+
+import java.util.List;
+
+import depromeet.lessonfour.server.report.app.dto.response.ToiletColorCount;
+import depromeet.lessonfour.server.report.app.dto.response.ToiletShapeCount;
+import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletPainDistribution;
+import depromeet.lessonfour.server.report.domain.vo.monthly.ToiletTimeDistribution;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+
+public final class MonthlyToiletStats {
+  private MonthlyToiletStats() {}
+
+  // 통증 분포 가중평균 (버킷 대표치: 10/30/50/70/90)
+  public static double avgPain(ToiletPainDistribution pd) {
+    if (pd == null) return 0;
+    int n = pd.veryLow() + pd.low() + pd.medium() + pd.high() + pd.veryHigh();
+    if (n == 0) return 0;
+    double sum =
+        10.0 * pd.veryLow()
+            + 30.0 * pd.low()
+            + 50.0 * pd.medium()
+            + 70.0 * pd.high()
+            + 90.0 * pd.veryHigh();
+    return sum / n;
+  }
+
+  // 소요시간 분포 평균 (대표치: 3/7.5/12분)
+  public static double avgMinutes(ToiletTimeDistribution td) {
+    if (td == null) return 0;
+    int n = td.within5min() + td.over5min() + td.over10min();
+    if (n == 0) return 0;
+    double sum = 3.0 * td.within5min() + 7.5 * td.over5min() + 12.0 * td.over10min();
+    return sum / n;
+  }
+
+  public static int totalRecords(ToiletTimeDistribution td) {
+    if (td == null) return 0;
+    return td.within5min() + td.over5min() + td.over10min();
+  }
+
+  public static boolean hasBlood(List<ToiletColorCount> colors) {
+    if (colors == null) return false;
+    return colors.stream().anyMatch(c -> c.color() == ToiletColor.RED && c.count() > 0);
+  }
+
+  public static boolean hasAbnormalColor(List<ToiletColorCount> colors) {
+    if (colors == null) return false;
+    return colors.stream()
+        .anyMatch(
+            c ->
+                (c.color() == ToiletColor.GRAY || c.color() == ToiletColor.BLACK) && c.count() > 0);
+  }
+
+  public static boolean goodColorMostly(List<ToiletColorCount> colors) {
+    if (colors == null || colors.isEmpty()) return false;
+    int good =
+        colors.stream()
+            .filter(
+                c ->
+                    c.color() == ToiletColor.DARK_BROWN
+                        || c.color() == ToiletColor.GOLD
+                        || c.color() == ToiletColor.DEFAULT)
+            .mapToInt(ToiletColorCount::count)
+            .sum();
+    int total = colors.stream().mapToInt(ToiletColorCount::count).sum();
+    return total > 0 && good >= 0.6 * total; // 정책치 60%
+  }
+
+  public static boolean goodShapeMostly(List<ToiletShapeCount> shapes) {
+    if (shapes == null || shapes.isEmpty()) return false;
+    int good =
+        shapes.stream()
+            .filter(s -> s.shape() == ToiletShape.BANANA)
+            .mapToInt(ToiletShapeCount::count)
+            .sum();
+    int total = shapes.stream().mapToInt(ToiletShapeCount::count).sum();
+    return total > 0 && good >= 0.6 * total; // 정책치 60%
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
@@ -225,6 +225,11 @@ public class SuggestionPolicy {
     // 기존 generatePooSuggestions(DailyToiletReport) 로직을
     // WeeklyToiletReport의 평균/any 기반 API로 그대로 적용
 
+    // 무기록: 분석 스킵
+    if (weekly.getNumberOfRecords() == 0) {
+      return null; // 상위에서 null-safe 처리
+    }
+
     // 가장 심각한 증상부터 체크
     if (weekly.hasBlood()) {
       return ToiletSuggestion.BLOODY_STOOL;
@@ -351,21 +356,26 @@ public class SuggestionPolicy {
     boolean goodShape = MonthlyToiletStats.goodShapeMostly(monthlyToiletReport.shapeCount());
     boolean goodColor = MonthlyToiletStats.goodColorMostly(monthlyToiletReport.colorCount());
 
-    Suggestion.ToiletSuggestion toiletSuggestion;
-    if (hasBlood) {
-      toiletSuggestion = Suggestion.ToiletSuggestion.BLOODY_STOOL;
-    } else if (colorAbn) {
-      toiletSuggestion = Suggestion.ToiletSuggestion.COLOR_ABNORMAL;
-    } else if (avgPain >= PAINFUL_THRESHOLD) {
-      toiletSuggestion = Suggestion.ToiletSuggestion.PAINFUL_DEFECATION;
-    } else if (totalRecords < CONSTIPATION_THRESHOLD) {
-      toiletSuggestion = Suggestion.ToiletSuggestion.CONSTIPATION;
-    } else if (avgMinutes > NORMAL_DURATION_THRESHOLD) {
-      toiletSuggestion = Suggestion.ToiletSuggestion.LONG_DEFECATION_TIME;
-    } else {
-      if (goodShape) toiletSuggestion = Suggestion.ToiletSuggestion.IDEAL_SHAPE;
-      else if (goodColor) toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_COLOR;
-      else toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_REGULAR;
+    Suggestion.ToiletSuggestion toiletSuggestion = null;
+    if (totalRecords > 0) {
+      if (hasBlood) {
+        toiletSuggestion = Suggestion.ToiletSuggestion.BLOODY_STOOL;
+      } else if (colorAbn) {
+        toiletSuggestion = Suggestion.ToiletSuggestion.COLOR_ABNORMAL;
+      } else if (avgPain >= PAINFUL_THRESHOLD) {
+        toiletSuggestion = Suggestion.ToiletSuggestion.PAINFUL_DEFECATION;
+      } else if (totalRecords < CONSTIPATION_THRESHOLD) {
+        toiletSuggestion = Suggestion.ToiletSuggestion.CONSTIPATION;
+      } else if (avgMinutes > NORMAL_DURATION_THRESHOLD) {
+        toiletSuggestion = Suggestion.ToiletSuggestion.LONG_DEFECATION_TIME;
+      } else {
+        if (goodShape)
+          toiletSuggestion = Suggestion.ToiletSuggestion.IDEAL_SHAPE;
+        else if (goodColor)
+          toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_COLOR;
+        else
+          toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_REGULAR;
+      }
     }
 
     // 3) 습관 권고: 스트레스/물 기준(주간과 유사)

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
@@ -10,12 +10,17 @@ import org.springframework.stereotype.Component;
 import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.DailyToiletReport;
 import depromeet.lessonfour.server.report.domain.vo.DayType;
+import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
 import depromeet.lessonfour.server.report.domain.vo.Suggestion;
 import depromeet.lessonfour.server.report.domain.vo.Suggestion.HabitSuggestion;
 import depromeet.lessonfour.server.report.domain.vo.Suggestion.ToiletSuggestion;
 import depromeet.lessonfour.server.report.domain.vo.Suggestion.WaterSuggestion;
 import depromeet.lessonfour.server.report.domain.vo.ToiletEvaluationLevel;
 import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyToiletReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyToiletReport;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 
 @Component
@@ -176,5 +181,217 @@ public class SuggestionPolicy {
     }
 
     return result;
+  }
+
+  // 주간용
+  public Suggestion evaluateWeekly(
+      WeeklyActivityReport weeklyActivityReport, WeeklyToiletReport weeklyToiletReport) {
+
+    WaterSuggestion waterSuggestion = generateWeeklyWaterSuggestion(weeklyActivityReport);
+    ToiletSuggestion toiletSuggestion = generateWeeklyPooSuggestions(weeklyToiletReport);
+    List<HabitSuggestion> habitSuggestions =
+        generateWeeklyHabitSuggestions(weeklyActivityReport, weeklyToiletReport);
+
+    return new Suggestion(waterSuggestion, toiletSuggestion, habitSuggestions);
+  }
+
+  private WaterSuggestion generateWeeklyWaterSuggestion(WeeklyActivityReport weeklyActivityReport) {
+    // 일주일 동안 waterEvaluations를 다 flatten 한 뒤
+    List<WaterEvaluation> all =
+        weeklyActivityReport.getDailyReports().stream()
+            .flatMap(r -> r.getWaterEvaluations().stream())
+            .toList();
+
+    if (all.isEmpty()) {
+      return WaterSuggestion.NONE;
+    }
+
+    // 평균 컵 수 (quantity)로 레벨 판단
+    double avgQuantity = all.stream().mapToInt(WaterEvaluation::getQuantity).average().orElse(0);
+
+    // 나중에 공통 util로 뺄 수 있음.
+    if (avgQuantity >= 8) {
+      return WaterSuggestion.HIGH;
+    } else if (avgQuantity >= 5) {
+      return WaterSuggestion.MEDIUM;
+    } else if (avgQuantity > 0) {
+      return WaterSuggestion.LOW;
+    } else {
+      return WaterSuggestion.NONE;
+    }
+  }
+
+  private ToiletSuggestion generateWeeklyPooSuggestions(WeeklyToiletReport weekly) {
+    // 기존 generatePooSuggestions(DailyToiletReport) 로직을
+    // WeeklyToiletReport의 평균/any 기반 API로 그대로 적용
+
+    // 가장 심각한 증상부터 체크
+    if (weekly.hasBlood()) {
+      return ToiletSuggestion.BLOODY_STOOL;
+    }
+
+    if (weekly.hasAbnormalColor()) {
+      return ToiletSuggestion.COLOR_ABNORMAL;
+    }
+
+    // 배변 시 통증 (주간 평균)
+    if (weekly.getAveragePain() >= PAINFUL_THRESHOLD) {
+      return ToiletSuggestion.PAINFUL_DEFECATION;
+    }
+
+    // 변비 판정: 기록이 적고/딱딱한 모양이 많은지는 WeeklyToiletReport에 별도 메서드 추가해서 더 고도화 가능
+    if (weekly.getNumberOfRecords() < CONSTIPATION_THRESHOLD) {
+      return ToiletSuggestion.CONSTIPATION;
+    }
+
+    // 주간 전체적으로 묽은 변이 많다/딱딱한 변이 많다 판단도
+    // 필요하면 WeeklyToiletReport에 카운트 메서드 추가해서 적용 가능
+
+    // 배변 시간이 긴 경우 (주간 평균 시간)
+    if (weekly.getAverageDuration() > NORMAL_DURATION_THRESHOLD) {
+      return ToiletSuggestion.LONG_DEFECATION_TIME;
+    }
+
+    // 정상적인 경우들 (주간 종합 레벨 + 평균)
+    ToiletEvaluationLevel level = weekly.getLevel();
+    if ((level == ToiletEvaluationLevel.GOOD || level == ToiletEvaluationLevel.VERY_GOOD)
+        && weekly.getAverageDuration() <= NORMAL_DURATION_THRESHOLD
+        && weekly.getAveragePain() <= PAINFUL_THRESHOLD) {
+
+      if (weekly.hasGoodShape()) {
+        return ToiletSuggestion.IDEAL_SHAPE;
+      }
+      if (weekly.hasGoodColor()) {
+        return ToiletSuggestion.HEALTHY_COLOR;
+      }
+      return ToiletSuggestion.HEALTHY_REGULAR;
+    }
+
+    // 통증 거의 없는 주간
+    if (weekly.getAveragePain() <= PAIN_MILD_THRESHOLD) {
+      return ToiletSuggestion.PAIN_FREE;
+    }
+
+    // 적절한 시간 내 배변
+    if (weekly.getAverageDuration() <= NORMAL_DURATION_THRESHOLD) {
+      return ToiletSuggestion.NORMAL_DURATION;
+    }
+
+    return ToiletSuggestion.HEALTHY_REGULAR;
+  }
+
+  private List<HabitSuggestion> generateWeeklyHabitSuggestions(
+      WeeklyActivityReport weeklyActivityReport, WeeklyToiletReport weeklyToiletReport) {
+
+    List<HabitSuggestion> result = new ArrayList<>();
+
+    // 스트레스 많은 날이 일정 횟수 이상이면 HIGH_STRESS_LEVEL
+    if (weeklyActivityReport.highStressDays() >= 3) {
+      result.add(HabitSuggestion.HIGH_STRESS_LEVEL);
+    } else if (weeklyActivityReport.highStressDays() == 0) {
+      result.add(HabitSuggestion.STRESS_MANAGEMENT);
+    }
+
+    // 술을 마신 날이 있으면
+    if (weeklyToiletReport.drunkAlcohol()) {
+      result.add(HabitSuggestion.EXCESSIVE_ALCOHOL);
+    }
+
+    // 평균 배변 시간이 너무 길거나 너무 짧으면
+    if (weeklyToiletReport.getAverageDuration() > NORMAL_DURATION_THRESHOLD) {
+      result.add(HabitSuggestion.LONG_TOILET_TIME);
+    } else if (weeklyToiletReport.getAverageDuration() <= SHORT_DURATION_THRESHOLD) {
+      result.add(HabitSuggestion.SHORT_TOILET_TIME);
+    }
+
+    // 긍정적 습관 강화
+    if (result.isEmpty() || hasOnlyPositiveHabits(result)) {
+      // 스트레스 잘 관리
+      if (weeklyActivityReport.highStressDays() == 0) {
+        result.add(HabitSuggestion.STRESS_MANAGEMENT);
+      }
+      // 배변 점수 매우 좋음
+      if (weeklyToiletReport.getAverageScore() >= VERY_GOOD_CONDITION_THRESHOLD) {
+        result.add(HabitSuggestion.REGULAR_TOILET_HABITS);
+      }
+    }
+
+    return result;
+  }
+
+  // 월간용
+  public Suggestion evaluateMonthly(
+      MonthlyActivityReport monthlyActivityReport, MonthlyToiletReport monthlyToiletReport) {
+
+    // 1) 물: 월 평균 컵 수 → 레벨(주간과 동일 기준)
+    var allWater =
+        monthlyActivityReport.weeklyGroups().stream()
+            .flatMap(g -> g.dailyReports().stream())
+            .flatMap(d -> d.getWaterEvaluations().stream())
+            .toList();
+
+    Suggestion.WaterSuggestion waterSuggestion;
+    if (allWater.isEmpty()) {
+      waterSuggestion = Suggestion.WaterSuggestion.NONE;
+    } else {
+      double avgQ = allWater.stream().mapToInt(w -> w.getQuantity()).average().orElse(0);
+      // 주간과 같은 컵수 기준(8/5)을 재사용 — 공통 util로 뺄 수 있음
+      if (avgQ >= 8) waterSuggestion = Suggestion.WaterSuggestion.HIGH;
+      else if (avgQ >= 5) waterSuggestion = Suggestion.WaterSuggestion.MEDIUM;
+      else if (avgQ > 0) waterSuggestion = Suggestion.WaterSuggestion.LOW;
+      else waterSuggestion = Suggestion.WaterSuggestion.NONE;
+    }
+
+    // 2) 배변: 월간 분포 → 추정치로 동일 의사결정 순서 적용
+    double avgPain = MonthlyToiletStats.avgPain(monthlyToiletReport.painDistribution());
+    double avgMinutes = MonthlyToiletStats.avgMinutes(monthlyToiletReport.timeDistribution());
+    int totalRecords = MonthlyToiletStats.totalRecords(monthlyToiletReport.timeDistribution());
+    boolean hasBlood = MonthlyToiletStats.hasBlood(monthlyToiletReport.colorCount());
+    boolean colorAbn = MonthlyToiletStats.hasAbnormalColor(monthlyToiletReport.colorCount());
+    boolean goodShape = MonthlyToiletStats.goodShapeMostly(monthlyToiletReport.shapeCount());
+    boolean goodColor = MonthlyToiletStats.goodColorMostly(monthlyToiletReport.colorCount());
+
+    Suggestion.ToiletSuggestion toiletSuggestion;
+    if (hasBlood) {
+      toiletSuggestion = Suggestion.ToiletSuggestion.BLOODY_STOOL;
+    } else if (colorAbn) {
+      toiletSuggestion = Suggestion.ToiletSuggestion.COLOR_ABNORMAL;
+    } else if (avgPain >= PAINFUL_THRESHOLD) {
+      toiletSuggestion = Suggestion.ToiletSuggestion.PAINFUL_DEFECATION;
+    } else if (totalRecords < CONSTIPATION_THRESHOLD) {
+      toiletSuggestion = Suggestion.ToiletSuggestion.CONSTIPATION;
+    } else if (avgMinutes > NORMAL_DURATION_THRESHOLD) {
+      toiletSuggestion = Suggestion.ToiletSuggestion.LONG_DEFECATION_TIME;
+    } else {
+      if (goodShape) toiletSuggestion = Suggestion.ToiletSuggestion.IDEAL_SHAPE;
+      else if (goodColor) toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_COLOR;
+      else toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_REGULAR;
+    }
+
+    // 3) 습관 권고: 스트레스/물 기준(주간과 유사)
+    List<Suggestion.HabitSuggestion> habits = new ArrayList<>();
+    long highStressDays =
+        monthlyActivityReport.weeklyGroups().stream()
+            .flatMap(g -> g.dailyReports().stream())
+            .filter(
+                d ->
+                    d.getStressEvaluation() != null
+                        && d.getStressEvaluation().ordinal() >= StressEvaluation.MEDIUM.ordinal())
+            .count();
+
+    if (highStressDays >= 3) {
+      habits.add(Suggestion.HabitSuggestion.HIGH_STRESS_LEVEL);
+    } else {
+      habits.add(Suggestion.HabitSuggestion.STRESS_MANAGEMENT);
+    }
+
+    if (waterSuggestion == Suggestion.WaterSuggestion.LOW
+        || waterSuggestion == Suggestion.WaterSuggestion.NONE) {
+      habits.add(Suggestion.HabitSuggestion.LONG_TOILET_TIME); // 물 부족 시 행동 권고 대체
+    } else {
+      habits.add(Suggestion.HabitSuggestion.REGULAR_TOILET_HABITS);
+    }
+
+    return new Suggestion(waterSuggestion, toiletSuggestion, habits);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/policy/SuggestionPolicy.java
@@ -369,12 +369,9 @@ public class SuggestionPolicy {
       } else if (avgMinutes > NORMAL_DURATION_THRESHOLD) {
         toiletSuggestion = Suggestion.ToiletSuggestion.LONG_DEFECATION_TIME;
       } else {
-        if (goodShape)
-          toiletSuggestion = Suggestion.ToiletSuggestion.IDEAL_SHAPE;
-        else if (goodColor)
-          toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_COLOR;
-        else
-          toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_REGULAR;
+        if (goodShape) toiletSuggestion = Suggestion.ToiletSuggestion.IDEAL_SHAPE;
+        else if (goodColor) toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_COLOR;
+        else toiletSuggestion = Suggestion.ToiletSuggestion.HEALTHY_REGULAR;
       }
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/domain/repository/ToiletScoreRepository.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/repository/ToiletScoreRepository.java
@@ -1,6 +1,7 @@
 package depromeet.lessonfour.server.report.domain.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
@@ -17,4 +18,6 @@ public interface ToiletScoreRepository {
   Optional<ToiletScore> findMaxScoreBetween(Long userId, ActivityAt start, ActivityAt end);
 
   Optional<ToiletScore> findMinScoreBetween(Long userId, ActivityAt start, ActivityAt end);
+
+  List<ToiletScore> findAllBetween(Long userId, ActivityAt start, ActivityAt end);
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/service/ActivityEvaluationService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/service/ActivityEvaluationService.java
@@ -1,6 +1,7 @@
 package depromeet.lessonfour.server.report.domain.service;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -100,16 +101,21 @@ public class ActivityEvaluationService {
             .toList();
 
     // 1~7 / 8~14 / 15~21 / 22~28 / 29~end 버킷팅
-    LocalDate start = monthFirstDay;
-    LocalDate end = monthLastDay;
-
     List<MonthlyActivityReport.WeeklyGroup> groups = new ArrayList<>();
     int[] cuts = new int[] {7, 14, 21, 28, Integer.MAX_VALUE};
 
+    int monthLength = YearMonth.from(monthFirstDay).lengthOfMonth();
+
     for (int wi = 0; wi < 5; wi++) {
-      final int upper = cuts[wi];
-      LocalDate wStart = (wi == 0) ? start : start.withDayOfMonth(cuts[wi - 1] + 1);
-      LocalDate wEnd = (upper == Integer.MAX_VALUE) ? end : start.withDayOfMonth(upper);
+      int lowerBound = (wi == 0) ? 1 : (cuts[wi - 1] + 1);
+      if (lowerBound > monthLength) {
+        break; // 더 이상 유효한 주차 없음
+      }
+      int upperBound = Math.min(cuts[wi], monthLength);
+
+      LocalDate wStart = monthFirstDay.withDayOfMonth(lowerBound);
+      LocalDate wEnd = monthFirstDay.withDayOfMonth(upperBound);
+
       List<ActivityRecord> inWeek =
           sorted.stream()
               .filter(

--- a/src/main/java/depromeet/lessonfour/server/report/domain/service/ActivityEvaluationService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/service/ActivityEvaluationService.java
@@ -1,6 +1,8 @@
 package depromeet.lessonfour.server.report.domain.service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -14,6 +16,8 @@ import depromeet.lessonfour.server.report.domain.vo.DayType;
 import depromeet.lessonfour.server.report.domain.vo.FoodEvaluation;
 import depromeet.lessonfour.server.report.domain.vo.StressEvaluation;
 import depromeet.lessonfour.server.report.domain.vo.WaterEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -44,5 +48,100 @@ public class ActivityEvaluationService {
     }
 
     return new DailyActivityReport(foodEvaluations, waterEvaluations, stressEvaluation);
+  }
+
+  public WeeklyActivityReport evaluateWeekly(List<ActivityRecord> records) {
+    if (records == null || records.isEmpty()) {
+      return new WeeklyActivityReport(List.of());
+    }
+
+    // 날짜 오름차순 정렬 (뷰에서 월~일 순서대로 사용하기 좋게)
+    List<ActivityRecord> sorted =
+        records.stream()
+            .sorted(
+                Comparator.comparing(
+                    r -> r.getActivityAt().toDate() // ActivityAt -> LocalDate
+                    ))
+            .toList();
+
+    List<DailyActivityReport> dailyReports = new ArrayList<>();
+
+    for (ActivityRecord record : sorted) {
+      // 주간 컨텍스트에서는 전일 비교 필요 없으므로 previous = null
+      DailyActivityReport dailyReport = evaluate(null, record);
+      dailyReports.add(dailyReport);
+    }
+
+    return new WeeklyActivityReport(dailyReports);
+  }
+
+  public MonthlyActivityReport evaluateMonthly(
+      List<ActivityRecord> currentMonth,
+      List<ActivityRecord> lastMonth,
+      LocalDate monthFirstDay,
+      LocalDate monthLastDay) {
+    if (currentMonth == null || currentMonth.isEmpty()) {
+      int lastDangerous = 0;
+      if (lastMonth != null && !lastMonth.isEmpty()) {
+        lastDangerous =
+            (int)
+                lastMonth.stream()
+                    .map(r -> foodEvaluationPolicy.calculate(r.getFoodRecords(), DayType.TODAY))
+                    .filter(FoodEvaluation::isDangerous)
+                    .count();
+      }
+      return MonthlyActivityReport.empty(lastDangerous);
+    }
+
+    // 날짜 오름차순
+    List<ActivityRecord> sorted =
+        currentMonth.stream()
+            .sorted(Comparator.comparing(r -> r.getActivityAt().toDate()))
+            .toList();
+
+    // 1~7 / 8~14 / 15~21 / 22~28 / 29~end 버킷팅
+    LocalDate start = monthFirstDay;
+    LocalDate end = monthLastDay;
+
+    List<MonthlyActivityReport.WeeklyGroup> groups = new ArrayList<>();
+    int[] cuts = new int[] {7, 14, 21, 28, Integer.MAX_VALUE};
+
+    for (int wi = 0; wi < 5; wi++) {
+      final int upper = cuts[wi];
+      LocalDate wStart = (wi == 0) ? start : start.withDayOfMonth(cuts[wi - 1] + 1);
+      LocalDate wEnd = (upper == Integer.MAX_VALUE) ? end : start.withDayOfMonth(upper);
+      List<ActivityRecord> inWeek =
+          sorted.stream()
+              .filter(
+                  r -> {
+                    LocalDate d = r.getActivityAt().toDate();
+                    return !d.isBefore(wStart) && !d.isAfter(wEnd);
+                  })
+              .toList();
+      List<DailyActivityReport> daily =
+          inWeek.stream()
+              .map(r -> evaluate(null, r)) // previous=null (주간과 동일 로직)
+              .toList();
+      groups.add(new MonthlyActivityReport.WeeklyGroup(wi + 1, wStart, wEnd, daily));
+    }
+
+    int dangerousDays =
+        (int)
+            sorted.stream()
+                .map(r -> foodEvaluationPolicy.calculate(r.getFoodRecords(), DayType.TODAY))
+                .filter(FoodEvaluation::isDangerous)
+                .count();
+
+    int lastDangerous = 0;
+    if (lastMonth != null && !lastMonth.isEmpty()) {
+      lastDangerous =
+          (int)
+              lastMonth.stream()
+                  .map(r -> foodEvaluationPolicy.calculate(r.getFoodRecords(), DayType.TODAY))
+                  .filter(FoodEvaluation::isDangerous)
+                  .count();
+    }
+
+    return new MonthlyActivityReport(sorted.size(), groups, dangerousDays, lastDangerous);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/service/SuggestionService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/service/SuggestionService.java
@@ -8,6 +8,8 @@ import depromeet.lessonfour.server.report.domain.vo.DailyToiletReport;
 import depromeet.lessonfour.server.report.domain.vo.Suggestion;
 import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.monthly.MonthlyToiletReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyActivityReport;
+import depromeet.lessonfour.server.report.domain.vo.weekly.WeeklyToiletReport;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,7 +24,12 @@ public class SuggestionService {
   }
 
   public Suggestion suggest(
+      WeeklyActivityReport weeklyActivityReport, WeeklyToiletReport weeklyToiletReport) {
+    return suggestionPolicy.evaluateWeekly(weeklyActivityReport, weeklyToiletReport);
+  }
+
+  public Suggestion suggest(
       MonthlyActivityReport monthlyActivityReport, MonthlyToiletReport monthlyToiletReport) {
-    return Suggestion.dummy();
+    return suggestionPolicy.evaluateMonthly(monthlyActivityReport, monthlyToiletReport);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/monthly/MonthlyActivityReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/monthly/MonthlyActivityReport.java
@@ -1,8 +1,24 @@
 package depromeet.lessonfour.server.report.domain.vo.monthly;
 
-public record MonthlyActivityReport(int size) {
+import java.time.LocalDate;
+import java.util.List;
 
-  public static MonthlyActivityReport dummy() {
-    return new MonthlyActivityReport(1);
+import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
+
+public record MonthlyActivityReport(
+    int size,
+    List<WeeklyGroup> weeklyGroups,
+    int dangerousFoodDays, // 이 달 전체 'dangerous=true' 일수
+    int lastMonthDangerousDays // 지난달 dangerous 일수 (food 섹션 비교용)
+    ) {
+
+  public static record WeeklyGroup(
+      int weekIndex, // 1~5
+      LocalDate startDate, // yyyy-MM-dd
+      LocalDate endDate, // yyyy-MM-dd
+      List<DailyActivityReport> dailyReports) {}
+
+  public static MonthlyActivityReport empty(int lastMonthDangerousDays) {
+    return new MonthlyActivityReport(0, List.of(), 0, lastMonthDangerousDays);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/weekly/WeeklyActivityReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/weekly/WeeklyActivityReport.java
@@ -1,0 +1,35 @@
+package depromeet.lessonfour.server.report.domain.vo.weekly;
+
+import java.util.List;
+
+import depromeet.lessonfour.server.report.domain.vo.DailyActivityReport;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WeeklyActivityReport {
+
+  /** 해당 주(월~일)의 DailyActivityReport 리스트 (최대 7개, 기록 없으면 빈 DailyActivityReport 일 수도 있음) */
+  private final List<DailyActivityReport> dailyReports;
+
+  public int size() {
+    return dailyReports != null ? dailyReports.size() : 0;
+  }
+
+  /** 이 주에 “위험한 음식”이 포함된 날의 수 (대략적인 위험도 척도용) */
+  public long dangerousFoodDays() {
+    if (dailyReports == null) {
+      return 0;
+    }
+    return dailyReports.stream().filter(DailyActivityReport::hasDangerousFood).count();
+  }
+
+  /** 이 주에 스트레스가 높았던 날의 수 */
+  public long highStressDays() {
+    if (dailyReports == null) {
+      return 0;
+    }
+    return dailyReports.stream().filter(DailyActivityReport::hasStress).count();
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/weekly/WeeklyToiletReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/weekly/WeeklyToiletReport.java
@@ -1,0 +1,77 @@
+package depromeet.lessonfour.server.report.domain.vo.weekly;
+
+import java.util.List;
+
+import depromeet.lessonfour.server.report.domain.vo.DailyToiletReport;
+import depromeet.lessonfour.server.report.domain.vo.ToiletEvaluationLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WeeklyToiletReport {
+
+  /** 해당 주(월~일)의 DailyToiletReport 리스트 */
+  private final List<DailyToiletReport> dailyReports;
+
+  public int size() {
+    return dailyReports != null ? dailyReports.size() : 0;
+  }
+
+  /** 주간 평균 배변 점수 */
+  public double getAverageScore() {
+    if (dailyReports == null || dailyReports.isEmpty()) {
+      return 0;
+    }
+    return dailyReports.stream().mapToDouble(DailyToiletReport::getToiletScore).average().orElse(0);
+  }
+
+  public ToiletEvaluationLevel getLevel() {
+    return ToiletEvaluationLevel.from(getAverageScore());
+  }
+
+  public boolean hasBlood() {
+    return dailyReports != null && dailyReports.stream().anyMatch(DailyToiletReport::hasBlood);
+  }
+
+  public boolean hasAbnormalColor() {
+    return dailyReports != null
+        && dailyReports.stream().anyMatch(DailyToiletReport::hasAbnormalColor);
+  }
+
+  public boolean drunkAlcohol() {
+    return dailyReports != null && dailyReports.stream().anyMatch(DailyToiletReport::drunkAlcohol);
+  }
+
+  public double getAverageDuration() {
+    if (dailyReports == null || dailyReports.isEmpty()) {
+      return 0;
+    }
+    return dailyReports.stream()
+        .mapToDouble(DailyToiletReport::getAverageDuration)
+        .average()
+        .orElse(0);
+  }
+
+  public double getAveragePain() {
+    if (dailyReports == null || dailyReports.isEmpty()) {
+      return 0;
+    }
+    return dailyReports.stream().mapToDouble(DailyToiletReport::getAveragePain).average().orElse(0);
+  }
+
+  public int getNumberOfRecords() {
+    if (dailyReports == null) {
+      return 0;
+    }
+    return dailyReports.stream().mapToInt(DailyToiletReport::getNumberOfRecords).sum();
+  }
+
+  public boolean hasGoodShape() {
+    return dailyReports != null && dailyReports.stream().anyMatch(DailyToiletReport::hasGoodShape);
+  }
+
+  public boolean hasGoodColor() {
+    return dailyReports != null && dailyReports.stream().anyMatch(DailyToiletReport::hasGoodColor);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/infra/ToiletScoreQuery.java
+++ b/src/main/java/depromeet/lessonfour/server/report/infra/ToiletScoreQuery.java
@@ -3,6 +3,7 @@ package depromeet.lessonfour.server.report.infra;
 import static depromeet.lessonfour.server.report.domain.entity.QToiletScore.toiletScore;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -56,5 +57,16 @@ public class ToiletScoreQuery {
             .fetchFirst();
 
     return Optional.ofNullable(score);
+  }
+
+  public List<ToiletScore> findAllBetween(Long userId, ActivityAt start, ActivityAt end) {
+    return queryFactory
+        .selectFrom(toiletScore)
+        .where(
+            toiletScore.userId.eq(userId),
+            toiletScore.date.goe(start.toDate()),
+            toiletScore.date.lt(end.toDate()))
+        .orderBy(toiletScore.date.asc())
+        .fetch();
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/infra/ToiletScoreRepositoryImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/report/infra/ToiletScoreRepositoryImpl.java
@@ -1,6 +1,7 @@
 package depromeet.lessonfour.server.report.infra;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -40,5 +41,10 @@ public class ToiletScoreRepositoryImpl implements ToiletScoreRepository {
   @Override
   public Optional<ToiletScore> findMinScoreBetween(Long userId, ActivityAt start, ActivityAt end) {
     return query.findMinScoreBetween(userId, start, end);
+  }
+
+  @Override
+  public List<ToiletScore> findAllBetween(Long userId, ActivityAt start, ActivityAt end) {
+    return query.findAllBetween(userId, start, end);
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -86,7 +86,7 @@ class HomeE2ETest {
 
   private ActivityRecord createActivity(LocalDateTime dt) {
     List<Food> foods = foodRepository.findAll();
-    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.get(0)));
     return activityRecordRepository.save(
         ActivityRecord.createWithMeals(
             testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dt), items));
@@ -278,7 +278,7 @@ class HomeE2ETest {
 
     // 다른 사용자 기록/점수
     var foods = foodRepository.findAll();
-    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.get(0)));
     activityRecordRepository.save(
         ActivityRecord.createWithMeals(
             other.getId(),

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -1,0 +1,320 @@
+package depromeet.lessonfour.server.recordquery.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.food.domain.entity.Food;
+import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class HomeE2ETest {
+
+  @LocalServerPort int port;
+
+  @Autowired JwtTokenGenerator jwtTokenGenerator;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+  @Autowired FoodRepository foodRepository;
+  @Autowired JpaActivityRecordRepository activityRecordRepository;
+  @Autowired ToiletRecordRepository toiletRecordRepository;
+  @Autowired JdbcTemplate jdbcTemplate;
+
+  private String validJwtToken;
+  private Long testUserId;
+  private User testUser;
+  private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    testUser = createTestUser("home@test.com", "pw1234", "home-user");
+    testUserId = testUser.getId();
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+
+    // 테스트용 Food 한 개
+    if (foodRepository.count() == 0) {
+      Food f = Food.builder().name("사과").score(4.5).build();
+      foodRepository.save(f);
+    }
+  }
+
+  private User createTestUser(String email, String rawPw, String nickname) {
+    User u = User.register(email, nickname, passwordEncoder.encode(rawPw));
+    return userRepository.save(u);
+  }
+
+  private ActivityRecord createActivity(LocalDateTime dt) {
+    List<Food> foods = foodRepository.findAll();
+    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    return activityRecordRepository.save(
+        ActivityRecord.createWithMeals(
+            testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dt), items));
+  }
+
+  private ToiletRecord createToilet(LocalDateTime dt) {
+    var r =
+        ToiletRecord.register(
+            testUser,
+            true,
+            ToiletColor.DEFAULT,
+            ToiletShape.BANANA,
+            20,
+            5,
+            "note",
+            ActivityAt.from(dt));
+    toiletRecordRepository.save(r);
+    return r;
+  }
+
+  private void insertToiletScore(Long userId, LocalDate date, int score) {
+    jdbcTemplate.update(
+        "INSERT INTO toilet_score (user_id, date, score) VALUES (?, ?, ?)", userId, date, score);
+  }
+
+  @Test
+  @DisplayName("[home] 점수 75(GOOD) + 화장실 2건 + 활동존재 → hero=GOOD 이미지/컬러")
+  void home_ok_good() {
+    LocalDate date = LocalDate.of(2024, 10, 5);
+    // score=75 → GOOD(60–79)
+    insertToiletScore(testUserId, date, 75);
+    // records
+    createToilet(LocalDateTime.of(2024, 10, 5, 8, 0));
+    createToilet(LocalDateTime.of(2024, 10, 5, 14, 0));
+    // activity exists
+    createActivity(LocalDateTime.of(2024, 10, 5, 10, 0));
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.toiletRecordCount", equalTo(2))
+        .body("data.hasActivityRecord", equalTo(true))
+        // GOOD 매핑 확인
+        .body("data.heroImage", containsString("colon_good.png"))
+        .body("data.heroBackgroundColors", hasItems("#134DB1", "#588DFF"));
+  }
+
+  @Test
+  @DisplayName("[home] 점수 82(VERY_GOOD) + 기록없음 → hero=VERY_GOOD 이미지/컬러, 카운트0/활동false")
+  void home_ok_veryGood_noRecords() {
+    LocalDate date = LocalDate.of(2024, 10, 6);
+    insertToiletScore(testUserId, date, 82);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.toiletRecordCount", equalTo(0))
+        .body("data.hasActivityRecord", equalTo(false))
+        .body("data.heroImage", containsString("colon_very_good.png"))
+        .body("data.heroBackgroundColors", hasItems("#0C7C30", "#7DD357"));
+  }
+
+  @Test
+  @DisplayName("[home] 점수 15(VERY_BAD) → hero=VERY_BAD 이미지/컬러")
+  void home_ok_veryBad() {
+    LocalDate date = LocalDate.of(2024, 10, 7);
+    insertToiletScore(testUserId, date, 15);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.heroImage", containsString("colon_very_bad.png"))
+        .body("data.heroBackgroundColors", hasItems("#A4141E", "#FF535F"));
+  }
+
+  @Test
+  @DisplayName("[home] 경계값 매핑 확인: 60(GOOD), 40(AVERAGE), 20(BAD)")
+  void home_ok_boundaries() {
+    // 60 → GOOD
+    LocalDate d1 = LocalDate.of(2024, 10, 8);
+    insertToiletScore(testUserId, d1, 60);
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + d1.format(dateFormatter))
+        .then()
+        .statusCode(200)
+        .body("data.heroImage", containsString("colon_good.png"))
+        .body("data.heroBackgroundColors", hasItems("#134DB1", "#588DFF"));
+
+    // 40 → AVERAGE
+    LocalDate d2 = LocalDate.of(2024, 10, 9);
+    insertToiletScore(testUserId, d2, 40);
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + d2.format(dateFormatter))
+        .then()
+        .statusCode(200)
+        .body("data.heroImage", containsString("colon_medium.png"))
+        .body("data.heroBackgroundColors", hasItems("#2B42B4", "#8F58FF"));
+
+    // 20 → BAD
+    LocalDate d3 = LocalDate.of(2024, 10, 10);
+    insertToiletScore(testUserId, d3, 20);
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + d3.format(dateFormatter))
+        .then()
+        .statusCode(200)
+        .body("data.heroImage", containsString("colon_bad.png"))
+        .body("data.heroBackgroundColors", hasItems("#DD5612", "#F6A85F"));
+  }
+
+  @Test
+  @DisplayName("[home] 점수/활동/배변 모두 없음 → 카운트0/false, hero=VERY_BAD 기본 에셋")
+  void home_noData_defaultsToVeryBad() {
+    // Given: 아무 데이터도 넣지 않음
+    LocalDate date = LocalDate.of(2024, 10, 12);
+
+    // When & Then
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.toiletRecordCount", equalTo(0))
+        .body("data.hasActivityRecord", equalTo(false))
+        // 점수 미기록 → ReportClient가 0으로 보고 → VERY_BAD 매핑
+        .body("data.heroImage", containsString("colon_very_bad.png"))
+        .body("data.heroBackgroundColors", hasItems("#A4141E", "#FF535F"));
+  }
+
+  @Test
+  @DisplayName("[home] JWT 없이 접근 시 401")
+  void home_unauthorized_noToken() {
+    LocalDate date = LocalDate.of(2024, 10, 5);
+    given()
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("[home] 잘못된 날짜 형식 400")
+  void home_badRequest_invalidDate() {
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/invalid-date")
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("[home] 다른 사용자 데이터는 카운트/활동/점수에 반영되지 않는다")
+  void home_otherUser_notCounted() {
+    User other = createTestUser("other@ex.com", "pw", "other");
+    LocalDate date = LocalDate.of(2024, 10, 11);
+
+    // 다른 사용자 기록/점수
+    var foods = foodRepository.findAll();
+    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    activityRecordRepository.save(
+        ActivityRecord.createWithMeals(
+            other.getId(),
+            5,
+            StressLevel.MEDIUM,
+            ActivityAt.from(LocalDateTime.of(2024, 10, 11, 9, 0)),
+            items));
+    toiletRecordRepository.save(
+        ToiletRecord.register(
+            other,
+            true,
+            ToiletColor.DEFAULT,
+            ToiletShape.BANANA,
+            20,
+            5,
+            "other",
+            ActivityAt.from(LocalDateTime.of(2024, 10, 11, 8, 0))));
+    jdbcTemplate.update(
+        "INSERT INTO toilet_score (user_id, date, score) VALUES (?, ?, ?)",
+        other.getId(),
+        date,
+        95);
+
+    // 현재 사용자로 조회 → 0/false + hero는 기본(점수 없으면 VERY_BAD로 매핑됨? 구현체에 따라 0점 처리)
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get("/api/v1/home/" + date.format(dateFormatter))
+        .then()
+        .statusCode(200)
+        .body("status", equalTo(200))
+        .body("data.toiletRecordCount", equalTo(0))
+        .body("data.hasActivityRecord", equalTo(false))
+        // 점수 미기록이면 0 → VERY_BAD 매핑(영웅 이미지는 very_bad)
+        .body("data.heroImage", containsString("colon_very_bad.png"))
+        .body("data.heroBackgroundColors", hasItems("#A4141E", "#FF535F"));
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetMonthlyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetMonthlyReportE2ETest.java
@@ -1,0 +1,502 @@
+package depromeet.lessonfour.server.report.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.food.domain.entity.Food;
+import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class GetMonthlyReportE2ETest {
+
+  @LocalServerPort int port;
+
+  @Autowired JwtTokenGenerator jwtTokenGenerator;
+  @Autowired UserRepository userRepository;
+  @Autowired PasswordEncoder passwordEncoder;
+  @Autowired FoodRepository foodRepository;
+  @Autowired JpaActivityRecordRepository activityRecordRepository;
+  @Autowired ToiletRecordRepository toiletRecordRepository;
+
+  String validJwtToken;
+  Long testUserId;
+  User testUser;
+
+  final DateTimeFormatter ymFormatter = DateTimeFormatter.ofPattern("yyyy-MM");
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    testUser = createTestUser("monthly-report@example.com", "pw1234!", "monthly-user");
+    testUserId = testUser.getId();
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+
+    // 최소 1개 식품 확보 (isDangerous 로직의 임계치와 무관하게 이름만 쓰여도 매핑은 됨)
+    if (foodRepository.findAll().isEmpty()) {
+      foodRepository.save(Food.builder().name("사과").score(4.5).build());
+      foodRepository.save(Food.builder().name("라면").score(9.9).build());
+    }
+  }
+
+  private User createTestUser(String email, String password, String nickname) {
+    User user = User.register(email, nickname, passwordEncoder.encode(password));
+    return userRepository.save(user);
+  }
+
+  private ActivityRecord createActivity(
+      LocalDateTime dateTime,
+      String foodName,
+      MealTime mealTime,
+      int waterCups,
+      StressLevel stress) {
+    List<Food> foods =
+        foodRepository.findAll().stream().filter(f -> f.getName().equals(foodName)).toList();
+    Food chosen = foods.isEmpty() ? foodRepository.findAll().getFirst() : foods.getFirst();
+    List<MealFood> meals = List.of(new MealFood(mealTime, chosen));
+    return activityRecordRepository.save(
+        ActivityRecord.createWithMeals(
+            testUserId, waterCups, stress, ActivityAt.from(dateTime), meals));
+  }
+
+  private ToiletRecord createToilet(
+      LocalDateTime dateTime,
+      ToiletColor color,
+      ToiletShape shape,
+      Integer pain,
+      Integer duration,
+      String note) {
+    ToiletRecord rec =
+        ToiletRecord.register(
+            testUser,
+            true,
+            color,
+            shape,
+            pain != null ? pain : 10,
+            duration != null ? duration : 5,
+            note,
+            ActivityAt.from(dateTime));
+    toiletRecordRepository.save(rec);
+    return rec;
+  }
+
+  private String monthlyUrl(YearMonth ym) {
+    return "/api/v1/reports/monthly?yearMonth=" + ym.format(ymFormatter);
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 이번 달에 activity/toilet 데이터가 충분 → 전체 섹션 정상 반환")
+  void givenFullMonth_whenGenerateMonthly_thenOk() {
+    // 대상 월: 2024-01
+    YearMonth ym = YearMonth.of(2024, 1);
+    LocalDate start = ym.atDay(1);
+
+    // 1~7일: activity + toilet 생성(주 1)
+    for (int i = 0; i < 7; i++) {
+      LocalDate d = start.plusDays(i);
+      createActivity(d.atTime(9, 0), i == 1 ? "라면" : "사과", MealTime.LUNCH, 6, StressLevel.MEDIUM);
+      createToilet(d.atTime(8, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "note");
+    }
+
+    // 8~14일: activity 2일, toilet 2일(주 2)
+    createActivity(start.plusDays(8).atTime(10, 0), "사과", MealTime.BREAKFAST, 8, StressLevel.LOW);
+    createToilet(
+        start.plusDays(8).atTime(7, 0), ToiletColor.DARK_BROWN, ToiletShape.CREAM, 5, 3, null);
+
+    createActivity(start.plusDays(12).atTime(11, 0), "라면", MealTime.DINNER, 3, StressLevel.HIGH);
+    createToilet(start.plusDays(12).atTime(6, 0), ToiletColor.GOLD, ToiletShape.ROCK, 25, 8, null);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201)) // POST /monthly → SUCCESS_CREATE
+        .body("data", notNullValue())
+        // 상단 공통
+        .body("data.monthlyRecordCounts", notNullValue())
+        .body("data.userAverage", notNullValue())
+        .body("data.monthlyDefecationScore", notNullValue())
+        // 화장실 섹션들
+        .body("data.shape.items", notNullValue())
+        .body("data.timeDistribution.within5min", notNullValue())
+        .body("data.color.items", notNullValue())
+        .body("data.pain.titleMessage", notNullValue())
+        .body("data.timeOfDay.items", notNullValue())
+        // activity 섹션들
+        .body("data.food.weeklyGroups", notNullValue())
+        .body("data.water.items", notNullValue())
+        .body("data.stress.items", notNullValue())
+        .body("data.suggestion.items", notNullValue());
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 지난달 데이터가 없더라도 → 비교값 0으로 안전 반환")
+  void givenNoLastMonth_whenGenerateMonthly_thenOk() {
+    // 대상 월: 2024-03 (이전에 아무것도 안 넣음)
+    YearMonth ym = YearMonth.of(2024, 3);
+    LocalDate start = ym.atDay(1);
+
+    // 이번 달 일부만 데이터
+    createActivity(start.plusDays(1).atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.MEDIUM);
+    createToilet(
+        start.plusDays(1).atTime(8, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        .body("data.food.monthlyComparison.lastMonth", anyOf(equalTo(0), greaterThanOrEqualTo(0)))
+        .body("data.food.monthlyComparison.thisMonth", greaterThanOrEqualTo(0));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 이번 달 일부만 존재(weeklyGroups 빈/부분) → NPE 없이 매핑")
+  void givenSparseThisMonth_whenGenerateMonthly_thenOk() {
+    YearMonth ym = YearMonth.of(2024, 4);
+    LocalDate start = ym.atDay(1);
+
+    // 주1: activity만 1건
+    createActivity(start.plusDays(0).atTime(9, 0), "사과", MealTime.BREAKFAST, 0, StressLevel.LOW);
+    // 주2: toilet만 1건
+    createToilet(start.plusDays(10).atTime(8, 0), ToiletColor.GOLD, ToiletShape.ROCK, 20, 7, null);
+    // 나머지 주는 비움
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        .body("data.food.weeklyGroups", notNullValue())
+        .body("data.food.weeklyGroups.size()", greaterThanOrEqualTo(1))
+        .body("data.water.items", notNullValue())
+        .body("data.stress.items", notNullValue())
+        .body("data.shape.items", anyOf(notNullValue(), hasSize(greaterThanOrEqualTo(0))))
+        .body("data.color.items", anyOf(notNullValue(), hasSize(greaterThanOrEqualTo(0))));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 이번 달에 아무 기록도 없음 → 기본값으로 안전 반환")
+  void givenNoRecordsThisMonth_whenGenerateMonthly_thenOk() {
+    YearMonth ym = YearMonth.of(2024, 5);
+
+    // 어떤 기록도 생성하지 않음
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        .body("data", notNullValue())
+        // 빈 값/0으로 매핑되는 섹션들 존재 확인
+        .body("data.monthlyRecordCounts", notNullValue())
+        .body("data.monthlyDefecationScore", notNullValue())
+        .body("data.shape.items", anyOf(hasSize(0), notNullValue()))
+        .body("data.timeDistribution.within5min", anyOf(equalTo(0), notNullValue()))
+        .body("data.color.items", anyOf(hasSize(0), notNullValue()))
+        .body("data.pain.high", anyOf(equalTo(0), notNullValue()))
+        .body("data.timeOfDay.items", anyOf(hasSize(0), notNullValue()))
+        .body("data.food.weeklyGroups", anyOf(hasSize(0), notNullValue()))
+        .body("data.water.items", anyOf(hasSize(0), notNullValue()))
+        .body("data.stress.items", anyOf(hasSize(0), notNullValue()))
+        .body("data.suggestion.items", anyOf(hasSize(0), notNullValue()));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] RED가 1회라도 있으면 colorMessage가 RED 경고 문구")
+  void givenRedColorAppears_thenRedWarningMessage() {
+    YearMonth ym = YearMonth.of(2024, 6);
+    LocalDate d = ym.atDay(3);
+
+    // RED 1회, 나머지는 안전색 여러 번
+    createToilet(d.atTime(8, 0), ToiletColor.RED, ToiletShape.BANANA, 10, 5, null);
+    createToilet(d.plusDays(1).atTime(9, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+    createActivity(d.atTime(10, 0), "사과", MealTime.LUNCH, 6, StressLevel.MEDIUM);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.color.colorMessage", containsString("혈변은 건강의 적신호"));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] painDiff 방향(increased/decreased/same) 계산")
+  void painDiffDirection() {
+    // 대상 2024-07, 지난달 2024-06로 비교됨
+    YearMonth ym = YearMonth.of(2024, 7);
+
+    // 지난달(6월): pain >=50 하루 생성
+    LocalDate lastMonthDay = YearMonth.of(2024, 6).atDay(10);
+    createToilet(lastMonthDay.atTime(8, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 60, 5, null);
+
+    // 이번달(7월): pain >=50 이틀
+    LocalDate thisMonthDay = ym.atDay(5);
+    createToilet(thisMonthDay.atTime(8, 0), ToiletColor.DEFAULT, ToiletShape.ROCK, 70, 6, null);
+    createToilet(
+        thisMonthDay.plusDays(2).atTime(9, 0), ToiletColor.DEFAULT, ToiletShape.CREAM, 55, 7, null);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.pain.comparison.direction", equalTo("increased"))
+        .body("data.pain.comparison.count", equalTo(1));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 물 섭취 메시지 - 주차레벨 평균(HIGH) ⇒ 유지 격려")
+  void waterMessage_monthAvgHigh() {
+    YearMonth ym = YearMonth.of(2024, 10);
+    LocalDate start = ym.atDay(1);
+
+    // 1주차: HIGH 하루만 기록(그 주의 평균은 HIGH로 계산됨)
+    createActivity(start.plusDays(1).atTime(9, 0), "사과", MealTime.BREAKFAST, 8, StressLevel.LOW);
+
+    // 2주차: HIGH 하루
+    createActivity(start.plusDays(8).atTime(9, 0), "사과", MealTime.BREAKFAST, 9, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.water.message", anyOf(containsString("잘 섭취하고 계시군요"), containsString("유지")));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 물 섭취 0이어도 리포트 생성 및 권유 문구 노출")
+  void waterSection_handlesZeroData() {
+    YearMonth ym = YearMonth.of(2024, 9);
+    LocalDate start = ym.atDay(1);
+
+    // 이번 달에 activity는 있으나 water=0으로만 입력
+    createActivity(start.plusDays(0).atTime(9, 0), "사과", MealTime.BREAKFAST, 0, StressLevel.MEDIUM);
+    createActivity(start.plusDays(10).atTime(12, 0), "라면", MealTime.LUNCH, 0, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        // totalVolume 또는 items 기반 어느 쪽이든 0 상태를 안전히 표현해야 함
+        .body("data.water.totalVolume", anyOf(equalTo(0), nullValue()))
+        .body("data.water.items.size()", greaterThanOrEqualTo(0))
+        // 권유/가이드 문구(카피가 바뀌어도 '물' 단어 포함 정도로 완화)
+        .body(
+            "data.water.message",
+            anyOf(containsString("물"), containsString("수분"), containsString("마셔")));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 물 섭취 메시지 - 기록 없음 ⇒ 안내 문구")
+  void waterMessage_monthNone() {
+    YearMonth ym = YearMonth.of(2024, 8);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.water.message", anyOf(containsString("기록이 없어요"), containsString("자주 마셔")));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 말일 경계(29~말일) 5주차 버킷과 timeOfDay 매핑 검증(간단)")
+  void endOfMonthBucketAndTimeOfDay() {
+    YearMonth ym = YearMonth.of(2024, 2); // 29일까지 있는 달로 잡아도 OK
+    LocalDate d29 = ym.atDay(Math.min(29, ym.lengthOfMonth()));
+    // 오전/오후/저녁 각 1건
+    createToilet(d29.atTime(6, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+    createToilet(d29.atTime(13, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+    createToilet(d29.atTime(19, 0), ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.timeOfDay.items.size()", greaterThanOrEqualTo(3))
+        .body("data.timeOfDay.items.find { it.period == '오전' }.count", greaterThanOrEqualTo(1))
+        .body("data.timeOfDay.items.find { it.period == '오후' }.count", greaterThanOrEqualTo(1))
+        .body("data.timeOfDay.items.find { it.period == '저녁' }.count", greaterThanOrEqualTo(1));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] ISO 주 경계: 전월 말(하이) + 당월 초(로우) → 주 집계는 당월 일자만 반영")
+  void water_boundaryWeek_usesOnlyInMonthDays() {
+    YearMonth ym = YearMonth.of(2024, 10); // 2024-10
+    LocalDate first = ym.atDay(1); // 2024-10-01
+    LocalDate prevLast = first.minusDays(1); // 2024-09-30 (전월)
+
+    // 전월 말: HIGH(10컵) — 당월 집계에서 제외되어야 함
+    createActivity(prevLast.atTime(9, 0), "사과", MealTime.BREAKFAST, 10, StressLevel.LOW);
+
+    // 당월 초: LOW(4컵) — 당월 집계에 포함
+    createActivity(first.atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        // 월 메시지는 LOW로 수렴해야 함
+        .body(
+            "data.water.message",
+            anyOf(
+                containsString("늘려야"), // "물 섭취량을 늘려야 해요"
+                containsString("말라") // 카피 변형 대비
+                ))
+        // NONE이 아닌 주 1개만 생기므로, 해당 주 값은 LOW(600.0)이어야 함
+        .body("data.water.items.size()", greaterThanOrEqualTo(1))
+        .body("data.water.items[0].value", equalTo(600.0F));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 월 시작/끝 하루만 기록: 둘 다 HIGH → 월평균 HIGH 유지 메시지")
+  void water_monthStartEndOnly_highMaintained() {
+    YearMonth ym = YearMonth.of(2024, 8);
+    LocalDate first = ym.atDay(1);
+    LocalDate last = ym.atEndOfMonth();
+
+    // 시작일/말일만 HIGH(>=8컵)
+    createActivity(first.atTime(8, 30), "사과", MealTime.BREAKFAST, 8, StressLevel.LOW);
+    createActivity(last.atTime(20, 10), "사과", MealTime.DINNER, 9, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        // 정책상 MEDIUM/HIGH는 유지 계열 카피
+        .body("data.water.message", anyOf(containsString("잘 섭취하고 계시군요"), containsString("유지")))
+        // 주 아이템들 중 최소 하나는 HIGH(2000.0) 값을 가져야 함
+        .body("data.water.items.value", hasItem(2000.0F));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 미기록 섞임: HIGH 주 + NONE 주 + LOW 주 → NONE 제외 평균 = MEDIUM ⇒ 유지계열 카피")
+  void water_mixedMissing_excludesNoneInAverage() {
+    YearMonth ym = YearMonth.of(2024, 10);
+    LocalDate start = ym.atDay(1);
+
+    // 1주차: HIGH(≥8컵) 하루
+    createActivity(start.plusDays(1).atTime(9, 0), "사과", MealTime.BREAKFAST, 8, StressLevel.LOW);
+
+    // 2주차: NONE (아무 기록도 만들지 않음)
+
+    // 3주차: LOW(≤4컵) 하루
+    createActivity(
+        start.plusDays(14 + 1).atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        // NONE을 평균에서 제외 → HIGH(3)과 LOW(1)의 평균 ≈ 2 → MEDIUM
+        // 월 메시지는 MEDIUM/HIGH 묶음의 '유지' 계열 카피여야 함
+        .body("data.water.message", anyOf(containsString("유지"), containsString("잘 섭취")))
+        // 주 아이템 값들에 LOW(600.0)과 HIGH(2000.0)가 공존해야 함
+        .body("data.water.items.value", hasItems(600.0F, 2000.0F));
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetMonthlyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetMonthlyReportE2ETest.java
@@ -92,7 +92,7 @@ class GetMonthlyReportE2ETest {
       StressLevel stress) {
     List<Food> foods =
         foodRepository.findAll().stream().filter(f -> f.getName().equals(foodName)).toList();
-    Food chosen = foods.isEmpty() ? foodRepository.findAll().getFirst() : foods.getFirst();
+    Food chosen = foods.isEmpty() ? foodRepository.findAll().get(0) : foods.get(0);
     List<MealFood> meals = List.of(new MealFood(mealTime, chosen));
     return activityRecordRepository.save(
         ActivityRecord.createWithMeals(
@@ -498,5 +498,86 @@ class GetMonthlyReportE2ETest {
         .body("data.water.message", anyOf(containsString("유지"), containsString("잘 섭취")))
         // 주 아이템 값들에 LOW(600.0)과 HIGH(2000.0)가 공존해야 함
         .body("data.water.items.value", hasItems(600.0F, 2000.0F));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 2월(평년, 28일) → weeklyGroups는 4개, 4주차 endDate=말일(28)")
+  void februaryNonLeap_hasFourWeeklyGroups() {
+    YearMonth ym = YearMonth.of(2023, 2); // 28일
+    LocalDate first = ym.atDay(1);
+
+    // 최소 1건 생성(weeklyGroups 비지 않도록)
+    createActivity(first.atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        // 4주차까지만 생성
+        .body("data.food.weeklyGroups.size()", equalTo(4))
+        // 4주차의 endDate는 2월 28일
+        .body("data.food.weeklyGroups[3].endDate", equalTo(ym.atEndOfMonth().toString()))
+        // 5주차가 없어야 함
+        .body("data.food.weeklyGroups.find { it.weekLabel == '5주차' }", nullValue());
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 2월(윤년, 29일) → weeklyGroups는 5개, 5주차 범위=29~29")
+  void februaryLeap_hasFiveWeeklyGroups() {
+    YearMonth ym = YearMonth.of(2024, 2); // 윤년 29일
+    LocalDate first = ym.atDay(1);
+
+    // 최소 1건 생성
+    createActivity(first.atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        // 5주차까지 생성
+        .body("data.food.weeklyGroups.size()", equalTo(5))
+        // 5주차는 29~29
+        .body("data.food.weeklyGroups[4].startDate", equalTo(ym.atDay(29).toString()))
+        .body("data.food.weeklyGroups[4].endDate", equalTo(ym.atDay(29).toString()))
+        .body("data.food.weeklyGroups[4].weekLabel", equalTo("5주차"));
+  }
+
+  @Test
+  @DisplayName("[E2E][monthly] 31일인 달 → weeklyGroups는 5개, 5주차 범위=29~말일(31)")
+  void month31_hasFiveWeeklyGroupsAndFifthCovers29ToEnd() {
+    YearMonth ym = YearMonth.of(2024, 7); // 31일인 달
+    LocalDate first = ym.atDay(1);
+
+    // 최소 1건 생성
+    createActivity(first.atTime(9, 0), "사과", MealTime.BREAKFAST, 4, StressLevel.LOW);
+
+    given()
+        .header("Authorization", validJwtToken)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .post(monthlyUrl(ym))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(201))
+        // 5주차까지 생성
+        .body("data.food.weeklyGroups.size()", equalTo(5))
+        // 5주차는 29일부터 말일까지
+        .body("data.food.weeklyGroups[4].startDate", equalTo(ym.atDay(29).toString()))
+        .body("data.food.weeklyGroups[4].endDate", equalTo(ym.atEndOfMonth().toString()))
+        .body("data.food.weeklyGroups[4].weekLabel", equalTo("5주차"));
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
@@ -1,0 +1,310 @@
+package depromeet.lessonfour.server.report.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+
+import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
+import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
+import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
+import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
+import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
+import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.food.domain.entity.Food;
+import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
+import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+import depromeet.lessonfour.server.user.domain.entity.User;
+import depromeet.lessonfour.server.user.domain.repository.UserRepository;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Sql(
+    scripts = "/sql/cleanup.sql",
+    config = @SqlConfig(transactionMode = SqlConfig.TransactionMode.ISOLATED),
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class GetWeeklyReportE2ETest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private JwtTokenGenerator jwtTokenGenerator;
+  @Autowired private UserRepository userRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired private FoodRepository foodRepository;
+  @Autowired private JpaActivityRecordRepository activityRecordRepository;
+  @Autowired private ToiletRecordRepository toiletRecordRepository;
+
+  private String validJwtToken;
+  private Long testUserId;
+  private User testUser;
+  private final DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+  @BeforeEach
+  void setUp() {
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    testUser = createTestUser("weekly-report@example.com", "password123", "weekly-user");
+    testUserId = testUser.getId();
+    validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
+
+    // 최소 1개 식품 확보
+    foodRepository.save(Food.builder().name("사과").score(4.5).build());
+  }
+
+  private User createTestUser(String email, String password, String nickname) {
+    User user = User.register(email, nickname, passwordEncoder.encode(password));
+    return userRepository.save(user);
+  }
+
+  private ActivityRecord createActivity(LocalDateTime dateTime) {
+    List<Food> foods = foodRepository.findAll();
+    List<MealFood> meals = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
+    return activityRecordRepository.save(
+        ActivityRecord.createWithMeals(
+            testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dateTime), meals));
+  }
+
+  private ToiletRecord createToilet(
+      LocalDateTime dateTime,
+      Boolean isSuccessful,
+      ToiletColor color,
+      ToiletShape shape,
+      Integer pain,
+      Integer duration,
+      String note) {
+    ToiletRecord rec =
+        ToiletRecord.register(
+            testUser,
+            isSuccessful != null ? isSuccessful : true,
+            color,
+            shape,
+            pain != null ? pain : 10,
+            duration != null ? duration : 5,
+            note,
+            ActivityAt.from(dateTime));
+    toiletRecordRepository.save(rec);
+    return rec;
+  }
+
+  private String weeklyUrl(LocalDateTime dateTime) {
+    return "/api/v1/reports/weekly?dateTime=" + dateTime.format(dtf);
+  }
+
+  // 1) 7일 모두 activity + toilet 존재
+  @Test
+  @DisplayName("[E2E][weekly] 7일 모두 activity + toilet 존재 → 정상 리포트 반환")
+  void givenFullWeekActivityAndToilet_whenGetWeeklyReport_thenOk() {
+    // 주간 기준: 2024-01-15(월) ~ 2024-01-21(일)
+    LocalDateTime monday = LocalDateTime.of(2024, 1, 15, 10, 0);
+
+    // 월~일 모두 activity + toilet 생성
+    for (int i = 0; i < 7; i++) {
+      LocalDateTime day = monday.plusDays(i);
+      createActivity(day);
+      createToilet(day.withHour(8), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "메모");
+    }
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(weeklyUrl(monday.plusDays(3))) // 주 중 아무 날짜
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.defecationScore", notNullValue())
+        .body("data.defecationScore.dailyScore.size()", equalTo(7))
+        .body("data.userAverage", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 2) 일부 activity 없음 (toilet은 7일 모두 존재)
+  @Test
+  @DisplayName("[E2E][weekly] 일부 activity 없음 → NPE 없이 정상 리포트 반환")
+  void givenPartialActivityMissing_whenGetWeeklyReport_thenOk() {
+    LocalDateTime monday = LocalDateTime.of(2024, 1, 22, 10, 0);
+
+    // 월~일: toilet은 모두 생성
+    for (int i = 0; i < 7; i++) {
+      LocalDateTime day = monday.plusDays(i);
+      createToilet(day.withHour(9), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+    }
+
+    // activity는 월/수/금만 생성
+    createActivity(monday.plusDays(0)); // 월
+    createActivity(monday.plusDays(2)); // 수
+    createActivity(monday.plusDays(4)); // 금
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(weeklyUrl(monday.plusDays(3)))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.defecationScore", notNullValue())
+        .body("data.defecationScore.dailyScore.size()", equalTo(7))
+        .body("data.userAverage", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 3) 일부 toilet 없음 (activity는 7일 모두 존재)
+  @Test
+  @DisplayName("[E2E][weekly] 일부 toilet 없음 → NPE 없이 정상 리포트 반환")
+  void givenPartialToiletMissing_whenGetWeeklyReport_thenOk() {
+    LocalDateTime monday = LocalDateTime.of(2024, 1, 29, 10, 0);
+
+    // 월~일: activity 모두 생성
+    for (int i = 0; i < 7; i++) {
+      createActivity(monday.plusDays(i));
+    }
+
+    // toilet은 화/목/토만 생성
+    createToilet(
+        monday.plusDays(1).withHour(8),
+        true,
+        ToiletColor.DEFAULT,
+        ToiletShape.BANANA,
+        10,
+        5,
+        null); // 화
+    createToilet(
+        monday.plusDays(3).withHour(8),
+        true,
+        ToiletColor.DEFAULT,
+        ToiletShape.ROCK,
+        20,
+        8,
+        null); // 목
+    createToilet(
+        monday.plusDays(5).withHour(8),
+        true,
+        ToiletColor.DARK_BROWN,
+        ToiletShape.CREAM,
+        5,
+        3,
+        null); // 토
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(weeklyUrl(monday.plusDays(4)))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.defecationScore", notNullValue())
+        .body("data.defecationScore.dailyScore.size()", equalTo(7))
+        .body("data.userAverage", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 4) 일부 날짜는 activity + toilet 둘 다 없음 (중간에 구멍)
+  @Test
+  @DisplayName("[E2E][weekly] 일부 날짜에 activity/toilet 둘 다 없음 → 정상 리포트 반환")
+  void givenSomeDaysNoActivityAndToilet_whenGetWeeklyReport_thenOk() {
+    LocalDateTime monday = LocalDateTime.of(2024, 2, 5, 10, 0);
+
+    // 월/화: activity + toilet 있음
+    for (int i = 0; i < 2; i++) {
+      LocalDateTime day = monday.plusDays(i);
+      createActivity(day);
+      createToilet(day.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
+    }
+
+    // 수/목: 아무 기록 없음
+
+    // 금: activity만 있음
+    createActivity(monday.plusDays(4));
+
+    // 토: toilet만 있음
+    createToilet(
+        monday.plusDays(5).withHour(9), true, ToiletColor.GOLD, ToiletShape.ROCK, 15, 6, null);
+
+    // 일: 아무 기록 없음
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(weeklyUrl(monday.plusDays(3)))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.defecationScore", notNullValue())
+        .body("data.defecationScore.dailyScore.size()", equalTo(7))
+        .body("data.userAverage", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+
+  // 5) 해당 주간에 activity, toilet 모두 없음
+  @Test
+  @DisplayName("[E2E][weekly] 해당 주간에 어떤 기록도 없음 → 빈 주간 리포트(기본값)로 정상 반환")
+  void givenNoRecords_whenGetWeeklyReport_thenOk() {
+    LocalDateTime monday = LocalDateTime.of(2024, 2, 12, 10, 0);
+
+    // 아무 기록도 생성하지 않음
+
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(weeklyUrl(monday.plusDays(2)))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.updatedAt", notNullValue())
+        .body("data.defecationScore", notNullValue())
+        .body("data.defecationScore.dailyScore.size()", equalTo(7))
+        .body("data.userAverage", notNullValue())
+        .body("data.food", notNullValue())
+        .body("data.water", notNullValue())
+        .body("data.stress", notNullValue())
+        .body("data.suggestion", notNullValue());
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->
주간, 월간 리포트 및 홈 조회 구현
## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->
- 홈 화면 API 신규: GET /api/v1/home/{date}
  - 응답: 해당 날짜의 toiletRecordCount, hasActivityRecord, 히어로 이미지/배경색.
- 리포트 API 신규: GET /api/v1/reports/weekly
- 리포트 정책 수정
- E2E 테스트 추가: 홈/리포트 주요 케이스 커버.

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->
케이스별 e2e test 모두 통과

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->
클라이언트 측에서 요청한 인터페이스에 맞춰 dto 필드명 작성했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 홈 화면용 일별 요약 API(날짜별) 및 점수 기반 영웅 이미지/배경 노출
  * 주간 리포트 추가: 일별 점수, 음식·수분·스트레스·제안 섹션 포함

* **Enhancements**
  * 월간 리포트 대폭 확장: 시간대·색상·통증·식단·수분·제안 등 다중 섹션 및 주간 비교 통계
  * 월별 점수 통계(평균·주간별 평균) 및 주간 집계 워크플로 추가
  * 제안 로직에 주간/월간 평가 경로 추가

* **Tests**
  * 홈/주간/월간 리포트에 대한 엔드투엔드 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->