### PR TITLE
Fix/report 상위 계산 유틸 생성, 홈 무기록 케이스 대응

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
@@ -32,6 +32,10 @@ public class ToiletRecordClientImpl implements ToiletRecordClient {
 
   @Override
   public ToiletRecordClient.HeroAssets getToiletHeroAssets(int score) {
+    if (score == 0) {
+      var assets = toiletReportMapper.heroAssetsByLevel(ToiletEvaluationLevel.AVERAGE);
+      return new ToiletRecordClient.HeroAssets(assets.image(), assets.backgroundColors());
+    }
     var level = ToiletEvaluationLevel.from(score);
     var assets = toiletReportMapper.heroAssetsByLevel(level);
     return new ToiletRecordClient.HeroAssets(assets.image(), assets.backgroundColors());

--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetWeeklyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetWeeklyReportResponseDto.java
@@ -10,8 +10,7 @@ public record GetWeeklyReportResponseDto(
     FoodSection food,
     WaterSection water,
     StressSection stress,
-    SuggestionSection suggestion,
-    String externalLink) {
+    SuggestionSection suggestion) {
 
   public record DefecationScore(double lastWeek, double thisWeek, List<Double> dailyScore) {}
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/MonthlyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/MonthlyReportMapper.java
@@ -104,8 +104,8 @@ public class MonthlyReportMapper {
   }
 
   private static UserAverage mapUserAverage(double myAverage) {
-    double overallAvg = myAverage; // 전체 평균 미정 → 우선 동일값
-    double topPercent = (myAverage >= 80) ? 20.0 : (myAverage >= 60) ? 50.0 : 80.0;
+    double overallAvg = 60.0; // 전체 평균 미정 → 우선 주간과 동일값
+    double topPercent = ReportMapperUtils.estimateTopPercent(myAverage, overallAvg);
     String title = String.format("이번 달 배변 점수는\n상위 %.0f%%예요", topPercent);
     return new UserAverage(myAverage, overallAvg, topPercent, title);
   }
@@ -358,7 +358,7 @@ public class MonthlyReportMapper {
 
     if (ar == null || ar.weeklyGroups() == null || ar.weeklyGroups().isEmpty()) {
       return new GetMonthlyReportResponseDto.StressSection(
-          "스트레스 기록이 없어요\n마음 편한 한 달이었네요!",
+          "스트레스 기록이 없어요\n오늘부터 간단히 남겨봐요!",
           "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png",
           items);
     }
@@ -394,7 +394,7 @@ public class MonthlyReportMapper {
     if (base == null) {
       base =
           new GetDailyReportResponseDto.StressReport(
-              "스트레스 기록이 없어요\n마음 편한 한 달이었네요!",
+              "스트레스 기록이 없어요\n오늘부터 간단히 남겨봐요!",
               "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/ReportMapperUtils.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/ReportMapperUtils.java
@@ -1,0 +1,26 @@
+package depromeet.lessonfour.server.report.api.mapper;
+
+public final class ReportMapperUtils {
+	private ReportMapperUtils() {}
+
+	/**
+	 * 평균 avg 대비 점수 me의 상대 위치를 상위 백분위(작을수록 상위)로 추정.
+	 * 로지스틱: top = 100 / (1 + exp((me - avg) / k))
+	 *  - me == avg → 50.0
+	 *  - k(스케일)가 클수록 완만, 작을수록 가팔라짐 (기본 8.0)
+	 *  - 0.5 ~ 99.5 사이로 클램프
+	 *  - 소수 1자리 반올림
+	 */
+	public static double estimateTopPercent(double me, double avg) {
+		return estimateTopPercent(me, avg, 8.0);
+	}
+
+	public static double estimateTopPercent(double me, double avg, double k) {
+		if (k <= 0) k = 8.0;
+		double top = 100.0 / (1.0 + Math.exp((me - avg) / k));
+		// 안전 클램프 (완전 0/100 노출 방지)
+		top = Math.max(0.5, Math.min(99.5, top));
+		// 소수 1자리
+		return Math.round(top * 10.0) / 10.0;
+	}
+}

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/ReportMapperUtils.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/ReportMapperUtils.java
@@ -1,26 +1,22 @@
 package depromeet.lessonfour.server.report.api.mapper;
 
 public final class ReportMapperUtils {
-	private ReportMapperUtils() {}
+  private ReportMapperUtils() {}
 
-	/**
-	 * 평균 avg 대비 점수 me의 상대 위치를 상위 백분위(작을수록 상위)로 추정.
-	 * 로지스틱: top = 100 / (1 + exp((me - avg) / k))
-	 *  - me == avg → 50.0
-	 *  - k(스케일)가 클수록 완만, 작을수록 가팔라짐 (기본 8.0)
-	 *  - 0.5 ~ 99.5 사이로 클램프
-	 *  - 소수 1자리 반올림
-	 */
-	public static double estimateTopPercent(double me, double avg) {
-		return estimateTopPercent(me, avg, 8.0);
-	}
+  /**
+   * 평균 avg 대비 점수 me의 상대 위치를 상위 백분위(작을수록 상위)로 추정. 로지스틱: top = 100 / (1 + exp((me - avg) / k)) - me
+   * == avg → 50.0 - k(스케일)가 클수록 완만, 작을수록 가팔라짐 (기본 8.0) - 0.5 ~ 99.5 사이로 클램프 - 소수 1자리 반올림
+   */
+  public static double estimateTopPercent(double me, double avg) {
+    return estimateTopPercent(me, avg, 8.0);
+  }
 
-	public static double estimateTopPercent(double me, double avg, double k) {
-		if (k <= 0) k = 8.0;
-		double top = 100.0 / (1.0 + Math.exp((me - avg) / k));
-		// 안전 클램프 (완전 0/100 노출 방지)
-		top = Math.max(0.5, Math.min(99.5, top));
-		// 소수 1자리
-		return Math.round(top * 10.0) / 10.0;
-	}
+  public static double estimateTopPercent(double me, double avg, double k) {
+    if (k <= 0) k = 8.0;
+    double top = 100.0 / (1.0 + Math.exp((me - avg) / k));
+    // 안전 클램프 (완전 0/100 노출 방지)
+    top = Math.max(0.5, Math.min(99.5, top));
+    // 소수 1자리
+    return Math.round(top * 10.0) / 10.0;
+  }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
@@ -75,14 +75,7 @@ public class WeeklyReportMapper {
   private static UserAverage mapUserAverage(double thisWeekAverageScore) {
     double me = thisWeekAverageScore;
     double average = 60.0; // TODO: 실제 전체 평균으로 치환 예정
-    double topPercent;
-    if (me >= 80) {
-      topPercent = 20.0;
-    } else if (me >= 60) {
-      topPercent = 50.0;
-    } else {
-      topPercent = 80.0;
-    }
+    double topPercent = ReportMapperUtils.estimateTopPercent(me, average);
     return new UserAverage(me, average, topPercent);
   }
 
@@ -192,7 +185,7 @@ public class WeeklyReportMapper {
         || thisWeek.getDailyReports().isEmpty()) {
 
       return new StressSection(
-          "스트레스 기록이 없어요\n마음 편한 한 주였네요!",
+          "스트레스 기록이 없어요\n오늘부터 간단히 남겨봐요!",
           "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png",
           items);
     }
@@ -214,7 +207,7 @@ public class WeeklyReportMapper {
       // NONE 등에 대해 StressMapper가 null을 주는 경우를 위한 안전장치
       base =
           new GetDailyReportResponseDto.StressReport(
-              "스트레스 기록이 없어요\n마음 편한 한 주였네요!",
+              "스트레스 기록이 없어요\n오늘부터 간단히 남겨봐요!",
               "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/condition_medium.png");
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
@@ -62,7 +62,6 @@ public class WeeklyReportMapper {
 
     SuggestionSection suggestionSection = mapSuggestionSection(weeklyReport.suggestion());
 
-    // TODO: externalLink 은 일단 null 로 두고, 나중에 채우기
     return new GetWeeklyReportResponseDto(
         updatedAt,
         defecationScore,
@@ -70,8 +69,7 @@ public class WeeklyReportMapper {
         foodSection,
         waterSection,
         stressSection,
-        suggestionSection,
-        null);
+        suggestionSection);
   }
 
   private static UserAverage mapUserAverage(double thisWeekAverageScore) {

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -224,8 +224,8 @@ class HomeE2ETest {
   }
 
   @Test
-  @DisplayName("[home] 점수/활동/배변 모두 없음 → 카운트0/false, hero=VERY_BAD 기본 에셋")
-  void home_noData_defaultsToVeryBad() {
+  @DisplayName("[home] 점수/활동/배변 모두 없음 → 카운트0/false, hero=AVERAGE 기본 에셋")
+  void home_noData_defaultsToAverage() {
     // Given: 아무 데이터도 넣지 않음
     LocalDate date = LocalDate.of(2024, 10, 12);
 
@@ -241,9 +241,9 @@ class HomeE2ETest {
         .body("status", equalTo(200))
         .body("data.toiletRecordCount", equalTo(0))
         .body("data.hasActivityRecord", equalTo(false))
-        // 점수 미기록 → ReportClient가 0으로 보고 → VERY_BAD 매핑
-        .body("data.heroImage", containsString("colon_very_bad.png"))
-        .body("data.heroBackgroundColors", hasItems("#A4141E", "#FF535F"));
+        // 점수 미기록 → ReportClient가 0으로 보고 → AVERAGE 매핑
+        .body("data.heroImage", containsString("colon_medium.png"))
+        .body("data.heroBackgroundColors", hasItems("#2B42B4", "#8F58FF"));
   }
 
   @Test
@@ -302,7 +302,7 @@ class HomeE2ETest {
         date,
         95);
 
-    // 현재 사용자로 조회 → 0/false + hero는 기본(점수 없으면 VERY_BAD로 매핑됨? 구현체에 따라 0점 처리)
+    // 현재 사용자로 조회 → 0/false + hero는 기본(점수 없으면 AVERAGE로 매핑됨)
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -313,8 +313,8 @@ class HomeE2ETest {
         .body("status", equalTo(200))
         .body("data.toiletRecordCount", equalTo(0))
         .body("data.hasActivityRecord", equalTo(false))
-        // 점수 미기록이면 0 → VERY_BAD 매핑(영웅 이미지는 very_bad)
-        .body("data.heroImage", containsString("colon_very_bad.png"))
-        .body("data.heroBackgroundColors", hasItems("#A4141E", "#FF535F"));
+        // 점수 미기록이면 0 → AVERAGE 매핑(영웅 이미지는 AVERAGE)
+        .body("data.heroImage", containsString("colon_medium.png"))
+        .body("data.heroBackgroundColors", hasItems("#2B42B4", "#8F58FF"));
   }
 }


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->
- report 상위 계산 유틸 생성
- 홈 무기록 케이스 대응 : AVERAGE 케이스로 간주
- stress 무기록 케이스 멘트 유도성으로 변경

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 상위 백분위 계산 방식 개선으로 사용자 순위 표시에 더 정교한 결과 제공
  * 스트레스 기록이 없을 때 표시되는 기본 문구를 보다 적극적이고 안내형으로 업데이트
  * 일부 점수(0)에 대한 히어로 자산 선택 로직을 개선하여 화면 표시 일관성 향상

* **변경**
  * 주간 리포트 응답에서 외부 링크 항목 제거로 응답 필드 간소화

* **테스트**
  * 홈 화면 관련 E2E 테스트 기대값을 0점 기본 매핑이 평균(AVERAGE)으로 변경하여 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->