### PR TITLE
Fix/월간 리포트 매핑 수정

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetDailyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetDailyReportResponseDto.java
@@ -10,13 +10,13 @@ import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 
 public record GetDailyReportResponseDto(
     LocalDateTime updatedAt,
-    DailyToiletReport poo,
+    DailyToiletReportDto poo,
     DailyFoodReport food,
     DailyWaterReport water,
     DailyStressReport stress) {
 
   // POO
-  public record DailyToiletReport(
+  public record DailyToiletReportDto(
       double score, ToiletSummary summary, List<ToiletReportItem> items) {}
 
   public record ToiletSummary(

--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetMonthlyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetMonthlyReportResponseDto.java
@@ -47,7 +47,7 @@ public record GetMonthlyReportResponseDto(
 
     public static ColorCount from(ToiletColorCount toiletColorCount) {
       return new ColorCount(
-          toiletColorCount.color().getValue(),
+          toiletColorCount.color().name(),
           toiletColorCount.count(),
           toiletColorCount.color().equals(ToiletColor.RED) ? "전문가 상담 권장" : null);
     }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReport;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletReportItem;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletSummary;
@@ -25,7 +27,9 @@ import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPeriodCount;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletTimeDistribution;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class ToiletReportMapper {
 
@@ -60,7 +64,7 @@ public class ToiletReportMapper {
             .map(
                 shape ->
                     new MonthlyToiletShape(
-                        shape.shape().getValue(),
+                        shape.shape().name(),
                         shape.count(),
                         MESSAGE_BY_SHAPE.getOrDefault(shape.shape(), "")))
             .toList();
@@ -82,9 +86,10 @@ public class ToiletReportMapper {
 
     List<ToiletColorCount> colorCounts = report.getMostFrequentToiletColors();
 
-    // 색상 기록이 없는 경우
+    // 색상 기록이 없는 경우 - 월별 2건 이상의 주간 리포트, 주별 2건 이상의 일간 리포트가 필요하므로 발생하지 않아야 함
     if (colorCounts.isEmpty()) {
-      return new MonthlyColorSection("이번 달 배변 색상 기록이 없어요", "", List.of());
+      log.error("Monthly toilet color report mapping failed - no color records found");
+      throw new ServerException(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     // 가장 많이 등장한 색상, 여러 개인 경우 모두 노출

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -73,7 +73,6 @@ public class ToiletReportMapper {
   }
 
   /** 배변 색상 섹션 매핑 */
-  // TODO : 색상 우선 순위 적용
   public MonthlyColorSection mapColor(MonthlyReport report) {
     final Map<ToiletColor, String> COLOR_MESSAGE_MAP =
         Map.of(
@@ -81,8 +80,15 @@ public class ToiletReportMapper {
             ToiletColor.WHITE, "흰색은 건강의 적신호예요. 간이나 담도가 좋지 않은 상태일 수도 있어요. 빠른 병원 방문을 권장해요.",
             ToiletColor.BLACK, "흑변은 건강의 적신호예요. 위궤양, 위암 등 위 관련 문제일 수도 있어요. 즉시 병원을 방문하셔야 해요");
 
-    final List<ToiletColor> PRIORITY =
-        List.of(ToiletColor.RED, ToiletColor.WHITE, ToiletColor.BLACK);
+    // 색상 우선순위: 적색 > 흑색 > 흰색 > 녹색 > 황금색 > 갈색
+    final Map<ToiletColor, Integer> COLOR_PRIORITY =
+        Map.of(
+            ToiletColor.RED, 1,
+            ToiletColor.BLACK, 2,
+            ToiletColor.WHITE, 3,
+            ToiletColor.GREEN, 4,
+            ToiletColor.GOLD, 5,
+            ToiletColor.DARK_BROWN, 6);
 
     List<ToiletColorCount> colorCounts = report.getMostFrequentToiletColors();
 
@@ -92,15 +98,31 @@ public class ToiletReportMapper {
       throw new ServerException(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 
-    // 가장 많이 등장한 색상, 여러 개인 경우 모두 노출
-    ToiletColorCount mostFrequentColor = colorCounts.getFirst();
+    // 색상 우선순위에 따라 정렬 (빈도수가 같으면 우선순위 높은 색상이 먼저)
+    List<ToiletColorCount> sortedColorCounts =
+        colorCounts.stream()
+            .sorted(
+                (a, b) -> {
+                  // 빈도수가 다르면 빈도수로 내림차순 정렬
+                  if (a.count() != b.count()) {
+                    return Integer.compare(b.count(), a.count());
+                  }
+                  // 빈도수가 같으면 우선순위로 오름차순 정렬
+                  return Integer.compare(
+                      COLOR_PRIORITY.getOrDefault(a.color(), 999),
+                      COLOR_PRIORITY.getOrDefault(b.color(), 999));
+                })
+            .toList();
+
+    // 가장 많이 등장한 색상 (우선순위가 적용된 첫 번째 색상)
+    ToiletColorCount mostFrequentColor = sortedColorCounts.getFirst();
     String titleMessage = "가장 많이 확인한 색상은\n" + mostFrequentColor.color().getValue() + "이에요";
 
     // 색상에 따른 경고 메시지
     String colorWarningMessage = COLOR_MESSAGE_MAP.getOrDefault(mostFrequentColor.color(), "");
 
     // item 매핑
-    List<ColorCount> monthlyColorCount = colorCounts.stream().map(ColorCount::from).toList();
+    List<ColorCount> monthlyColorCount = sortedColorCounts.stream().map(ColorCount::from).toList();
 
     return new MonthlyColorSection(titleMessage, colorWarningMessage, monthlyColorCount);
   }
@@ -141,11 +163,11 @@ public class ToiletReportMapper {
 
     // title message
     StringBuilder builder = new StringBuilder(mostFrequent.period().getValue());
-    if (periodCounts.get(1).count() == mostFrequent.count()) {
+    if (periodCounts.size() >= 2 && periodCounts.get(1).count() == mostFrequent.count()) {
       builder.append(",").append(periodCounts.get(1).period().getValue());
     }
 
-    if (periodCounts.getLast().count() == mostFrequent.count()) {
+    if (periodCounts.size() >= 3 && periodCounts.getLast().count() == mostFrequent.count()) {
       builder.append(",").append(periodCounts.getLast().period().getValue());
     }
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -52,7 +52,6 @@ public class ToiletReportMapper {
     final Map<ToiletShape, String> MESSAGE_BY_SHAPE =
         Map.of(
             ToiletShape.RABBIT, "변비 주의",
-            ToiletShape.ROCK, "",
             ToiletShape.BANANA, "",
             ToiletShape.CORN, "수분 충전 필요",
             ToiletShape.CREAM, "설사 주의",

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.exception.ServerException;
-import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReport;
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReportDto;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletReportItem;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletSummary;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.ColorCount;
@@ -20,6 +20,7 @@ import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportRespo
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyTimeDistributionSection;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyToiletShape;
 import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletColorCount;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPainDistribution;
@@ -34,8 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ToiletReportMapper {
 
   // 일간 리포트
-  public DailyToiletReport mapDaily(
-      depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport dailyToiletReport) {
+  public DailyToiletReportDto mapDaily(DailyToiletReport dailyToiletReport) {
     return DailyMapper.map(dailyToiletReport);
   }
 
@@ -259,13 +259,13 @@ public class ToiletReportMapper {
     private static final String message =
         "전문가의 상담이 필요해요. 복통이 매우 심했다면 단순한 식사 문제를 넘어서 장염이나 자극적인 음식으로 인한 장 트러블일 수 있습니다.";
 
-    static DailyToiletReport map(
+    static DailyToiletReportDto map(
         depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport dailyToiletReport) {
       if (dailyToiletReport.getLevel() == ToiletEvaluationLevel.NONE) {
         return null;
       }
       HeroCharacter heroCharacter = characterMap.get(dailyToiletReport.getLevel());
-      return new DailyToiletReport(
+      return new DailyToiletReportDto(
           dailyToiletReport.getToiletScore(),
           new ToiletSummary(
               heroCharacter.image(),

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ToiletShape {
   RABBIT("토끼"),
-  ROCK("돌"),
   CORN("옥수수"),
   BANANA("바나나"),
   CREAM("크림"),
@@ -18,7 +17,7 @@ public enum ToiletShape {
 
   public int getScore() {
     return switch (this) {
-      case RABBIT, ROCK -> -15;
+      case RABBIT -> -15;
       case PORRIDGE -> -10; // 묽음
       case CORN -> -5;
       case CREAM, WATER -> 10;

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -196,7 +196,7 @@ class GetDailyReportE2ETest {
     LocalDateTime base = LocalDateTime.of(2024, 1, 18, 10, 0);
 
     createToilet(base.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "ok");
-    createToilet(base.withHour(9), false, ToiletColor.DEFAULT, ToiletShape.ROCK, 30, 12, "fail");
+    createToilet(base.withHour(9), false, ToiletColor.DEFAULT, ToiletShape.CORN, 30, 12, "fail");
     createToilet(base.withHour(12), true, null, ToiletShape.CREAM, 5, 3, null); // color null
     createToilet(base.withHour(18), true, ToiletColor.DARK_BROWN, null, 0, 2, null); // shape null
     createToilet(base.withHour(20), true, null, null, 25, 8, "둘다 null"); // both null

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
@@ -206,7 +206,7 @@ class GetWeeklyReportE2ETest {
         monday.plusDays(3).withHour(8),
         true,
         ToiletColor.DEFAULT,
-        ToiletShape.ROCK,
+        ToiletShape.CORN,
         20,
         8,
         null); // 목
@@ -258,7 +258,7 @@ class GetWeeklyReportE2ETest {
 
     // 토: toilet만 있음
     createToilet(
-        monday.plusDays(5).withHour(9), true, ToiletColor.GOLD, ToiletShape.ROCK, 15, 6, null);
+        monday.plusDays(5).withHour(9), true, ToiletColor.GOLD, ToiletShape.CORN, 15, 6, null);
 
     // 일: 아무 기록 없음
 
@@ -356,7 +356,7 @@ class GetWeeklyReportE2ETest {
         monday.plusDays(1).withHour(9),
         true,
         ToiletColor.DARK_BROWN,
-        ToiletShape.ROCK,
+        ToiletShape.CORN,
         15,
         6,
         "화요일");

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperColorTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperColorTest.java
@@ -1,0 +1,418 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
+import depromeet.lessonfour.server.common.exception.ServerException;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyColorSection;
+import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletColorCount;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+
+class ToiletReportMapperColorTest {
+
+  private ToiletReportMapper mapper;
+  private MonthlyReport mockReport;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+    mockReport = mock(MonthlyReport.class);
+  }
+
+  @Test
+  @DisplayName("빨간색이 가장 많을 때 혈변 경고 메시지를 포함한다")
+  void givenRedColorMostFrequent_whenMapColor_thenReturnWithBloodWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.RED, 10),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 5),
+            new ToiletColorCount(ToiletColor.GOLD, 3));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n적색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("혈변은 건강의 적신호예요. 대장염, 대장암, 치질 등의 문제일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().getFirst().color()).isEqualTo("RED");
+    assertThat(result.items().getFirst().count()).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("흰색이 가장 많을 때 간/담도 경고 메시지를 포함한다")
+  void givenWhiteColorMostFrequent_whenMapColor_thenReturnWithLiverWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.WHITE, 8),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 6),
+            new ToiletColorCount(ToiletColor.GOLD, 4));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n흰색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("흰색은 건강의 적신호예요. 간이나 담도가 좋지 않은 상태일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("검은색이 가장 많을 때 위장 경고 메시지를 포함한다")
+  void givenBlackColorMostFrequent_whenMapColor_thenReturnWithStomachWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.BLACK, 12),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 7),
+            new ToiletColorCount(ToiletColor.GOLD, 5));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n흑색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("흑변은 건강의 적신호예요. 위궤양, 위암 등 위 관련 문제일 수도 있어요. 즉시 병원을 방문하셔야 해요");
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("갈색이 가장 많을 때 경고 메시지가 없다")
+  void givenBrownColorMostFrequent_whenMapColor_thenReturnWithoutWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 15),
+            new ToiletColorCount(ToiletColor.GOLD, 8),
+            new ToiletColorCount(ToiletColor.GREEN, 5));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n갈색이에요");
+    assertThat(result.colorMessage()).isEmpty();
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("노란색이 가장 많을 때 경고 메시지가 없다")
+  void givenYellowColorMostFrequent_whenMapColor_thenReturnWithoutWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.GOLD, 11),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 9),
+            new ToiletColorCount(ToiletColor.GREEN, 6));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n황금색이에요");
+    assertThat(result.colorMessage()).isEmpty();
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("초록색이 가장 많을 때 경고 메시지가 없다")
+  void givenGreenColorMostFrequent_whenMapColor_thenReturnWithoutWarning() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.GREEN, 10),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 7),
+            new ToiletColorCount(ToiletColor.GOLD, 4));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n녹색이에요");
+    assertThat(result.colorMessage()).isEmpty();
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("색상 기록이 없으면 예외를 발생시킨다")
+  void givenEmptyColorList_whenMapColor_thenThrowException() {
+    // given
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(Collections.emptyList());
+
+    // when & then
+    assertThatThrownBy(() -> mapper.mapColor(mockReport))
+        .isInstanceOf(ServerException.class)
+        .hasFieldOrPropertyWithValue("baseErrorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  @DisplayName("단일 색상만 있을 때도 올바르게 매핑한다")
+  void givenSingleColor_whenMapColor_thenReturnCorrectly() {
+    // given
+    List<ToiletColorCount> colors = List.of(new ToiletColorCount(ToiletColor.DARK_BROWN, 20));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n갈색이에요");
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).color()).isEqualTo("DARK_BROWN");
+    assertThat(result.items().get(0).count()).isEqualTo(20);
+  }
+
+  @Test
+  @DisplayName("여러 색상이 있을 때 모든 색상을 올바르게 매핑한다")
+  void givenMultipleColors_whenMapColor_thenReturnAllColorsCorrectly() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 18),
+            new ToiletColorCount(ToiletColor.GOLD, 12),
+            new ToiletColorCount(ToiletColor.GREEN, 8),
+            new ToiletColorCount(ToiletColor.RED, 5),
+            new ToiletColorCount(ToiletColor.BLACK, 3));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items()).hasSize(5);
+    assertThat(result.items().get(0).color()).isEqualTo("DARK_BROWN");
+    assertThat(result.items().get(0).count()).isEqualTo(18);
+    assertThat(result.items().get(1).color()).isEqualTo("GOLD");
+    assertThat(result.items().get(1).count()).isEqualTo(12);
+    assertThat(result.items().get(2).color()).isEqualTo("GREEN");
+    assertThat(result.items().get(2).count()).isEqualTo(8);
+  }
+
+  @Test
+  @DisplayName("동일한 빈도수를 가진 색상들이 있을 때 우선순위에 따라 처리한다")
+  void givenSameFrequencyColors_whenMapColor_thenReturnByPriority() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 10),
+            new ToiletColorCount(ToiletColor.GOLD, 10),
+            new ToiletColorCount(ToiletColor.GREEN, 5));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n황금색이에요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("GOLD");
+    assertThat(result.items().get(1).color()).isEqualTo("DARK_BROWN");
+  }
+
+  @Test
+  @DisplayName("적색과 흑색이 동률일 때 적색이 우선순위로 선택된다")
+  void givenRedAndBlackWithSameCount_whenMapColor_thenReturnRedFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.RED, 10),
+            new ToiletColorCount(ToiletColor.BLACK, 10),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 5));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n적색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("혈변은 건강의 적신호예요. 대장염, 대장암, 치질 등의 문제일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("RED");
+    assertThat(result.items().get(1).color()).isEqualTo("BLACK");
+  }
+
+  @Test
+  @DisplayName("흑색과 흰색이 동률일 때 흑색이 우선순위로 선택된다")
+  void givenBlackAndWhiteWithSameCount_whenMapColor_thenReturnBlackFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.BLACK, 12),
+            new ToiletColorCount(ToiletColor.WHITE, 12),
+            new ToiletColorCount(ToiletColor.GREEN, 6));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n흑색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("흑변은 건강의 적신호예요. 위궤양, 위암 등 위 관련 문제일 수도 있어요. 즉시 병원을 방문하셔야 해요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("BLACK");
+    assertThat(result.items().get(1).color()).isEqualTo("WHITE");
+  }
+
+  @Test
+  @DisplayName("흰색과 녹색이 동률일 때 흰색이 우선순위로 선택된다")
+  void givenWhiteAndGreenWithSameCount_whenMapColor_thenReturnWhiteFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.WHITE, 8),
+            new ToiletColorCount(ToiletColor.GREEN, 8),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 4));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n흰색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("흰색은 건강의 적신호예요. 간이나 담도가 좋지 않은 상태일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("WHITE");
+    assertThat(result.items().get(1).color()).isEqualTo("GREEN");
+  }
+
+  @Test
+  @DisplayName("녹색과 황금색이 동률일 때 녹색이 우선순위로 선택된다")
+  void givenGreenAndGoldWithSameCount_whenMapColor_thenReturnGreenFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.GREEN, 15),
+            new ToiletColorCount(ToiletColor.GOLD, 15),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 10));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n녹색이에요");
+    assertThat(result.colorMessage()).isEmpty();
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("GREEN");
+    assertThat(result.items().get(1).color()).isEqualTo("GOLD");
+  }
+
+  @Test
+  @DisplayName("황금색과 갈색이 동률일 때 황금색이 우선순위로 선택된다")
+  void givenGoldAndBrownWithSameCount_whenMapColor_thenReturnGoldFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.GOLD, 20),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 20),
+            new ToiletColorCount(ToiletColor.GREEN, 15));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n황금색이에요");
+    assertThat(result.colorMessage()).isEmpty();
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("GOLD");
+    assertThat(result.items().get(1).color()).isEqualTo("DARK_BROWN");
+  }
+
+  @Test
+  @DisplayName("모든 색상이 동률일 때 우선순위에 따라 적색이 먼저 선택된다")
+  void givenAllColorsWithSameCount_whenMapColor_thenReturnInPriorityOrder() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.RED, 10),
+            new ToiletColorCount(ToiletColor.BLACK, 10),
+            new ToiletColorCount(ToiletColor.WHITE, 10),
+            new ToiletColorCount(ToiletColor.GREEN, 10),
+            new ToiletColorCount(ToiletColor.GOLD, 10),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 10));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n적색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("혈변은 건강의 적신호예요. 대장염, 대장암, 치질 등의 문제일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(6);
+    // 우선순위 순서: 적색, 흑색, 흰색, 녹색, 황금색, 갈색
+    assertThat(result.items().get(0).color()).isEqualTo("RED");
+    assertThat(result.items().get(1).color()).isEqualTo("BLACK");
+    assertThat(result.items().get(2).color()).isEqualTo("WHITE");
+    assertThat(result.items().get(3).color()).isEqualTo("GREEN");
+    assertThat(result.items().get(4).color()).isEqualTo("GOLD");
+    assertThat(result.items().get(5).color()).isEqualTo("DARK_BROWN");
+  }
+
+  @Test
+  @DisplayName("적색과 갈색이 동률일 때 적색이 우선순위로 선택된다")
+  void givenRedAndBrownWithSameCount_whenMapColor_thenReturnRedFirst() {
+    // given
+    List<ToiletColorCount> colors =
+        List.of(
+            new ToiletColorCount(ToiletColor.RED, 15),
+            new ToiletColorCount(ToiletColor.DARK_BROWN, 15),
+            new ToiletColorCount(ToiletColor.GOLD, 10));
+    when(mockReport.getMostFrequentToiletColors()).thenReturn(colors);
+
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("가장 많이 확인한 색상은\n적색이에요");
+    assertThat(result.colorMessage())
+        .isEqualTo("혈변은 건강의 적신호예요. 대장염, 대장암, 치질 등의 문제일 수도 있어요. 빠른 병원 방문을 권장해요.");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).color()).isEqualTo("RED");
+    assertThat(result.items().get(1).color()).isEqualTo("DARK_BROWN");
+    assertThat(result.items().get(0).count()).isEqualTo(15);
+    assertThat(result.items().get(1).count()).isEqualTo(15);
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
@@ -1,0 +1,348 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReportDto;
+import depromeet.lessonfour.server.report.api.mapper.toilet.ToiletReportMapper.ToiletHeroAssets;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluation;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+
+class ToiletReportMapperDailyTest {
+
+  private ToiletReportMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+  }
+
+  @Test
+  @DisplayName("VERY_GOOD 레벨의 일간 리포트를 올바르게 매핑한다")
+  void givenVeryGoodLevel_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation mockItem =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.BANANA,
+            5,
+            1,
+            "test note");
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.VERY_GOOD, 95, List.of(mockItem));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.score()).isEqualTo(95);
+    assertThat(result.summary().image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_very_good.png");
+    assertThat(result.summary().backgroundColors()).containsExactly("#0C7C30", "#7DD357");
+    assertThat(result.summary().caption()).isEqualTo("기분 좋은 대장");
+    assertThat(result.summary().message()).isEqualTo("장 컨디션 아주 굿!");
+    assertThat(result.items()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("GOOD 레벨의 일간 리포트를 올바르게 매핑한다")
+  void givenGoodLevel_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation mockItem =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.BANANA,
+            5,
+            2,
+            null);
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.GOOD, 80, List.of(mockItem));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.score()).isEqualTo(80);
+    assertThat(result.summary().image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_good.png");
+    assertThat(result.summary().backgroundColors()).containsExactly("#134DB1", "#588DFF");
+    assertThat(result.summary().caption()).isEqualTo("신이 난 대장");
+    assertThat(result.summary().message()).isEqualTo("개운하실 것 같아요!");
+  }
+
+  @Test
+  @DisplayName("AVERAGE 레벨의 일간 리포트를 올바르게 매핑한다")
+  void givenAverageLevel_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation mockItem =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.ROCK,
+            5,
+            3,
+            "average");
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.AVERAGE, 60, List.of(mockItem));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.score()).isEqualTo(60);
+    assertThat(result.summary().image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_medium.png");
+    assertThat(result.summary().backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+    assertThat(result.summary().caption()).isEqualTo("얌전한 대장");
+    assertThat(result.summary().message()).isEqualTo("무난한 하루가 되었군요!");
+  }
+
+  @Test
+  @DisplayName("BAD 레벨의 일간 리포트를 올바르게 매핑한다")
+  void givenBadLevel_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation mockItem =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.WATER,
+            5,
+            4,
+            null);
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.BAD, 40, List.of(mockItem));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.score()).isEqualTo(40);
+    assertThat(result.summary().image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_bad.png");
+    assertThat(result.summary().backgroundColors()).containsExactly("#DD5612", "#F6A85F");
+    assertThat(result.summary().caption()).isEqualTo("속상한 대장");
+    assertThat(result.summary().message()).isEqualTo("잠시 관리가 필요해요!");
+  }
+
+  @Test
+  @DisplayName("VERY_BAD 레벨의 일간 리포트를 올바르게 매핑한다")
+  void givenVeryBadLevel_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation mockItem =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.RED,
+            ToiletShape.WATER,
+            10,
+            5,
+            "very bad");
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.VERY_BAD, 20, List.of(mockItem));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.score()).isEqualTo(20);
+    assertThat(result.summary().image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_very_bad.png");
+    assertThat(result.summary().backgroundColors()).containsExactly("#A4141E", "#FF535F");
+    assertThat(result.summary().caption()).isEqualTo("화가 잔뜩 난 대장");
+    assertThat(result.summary().message()).isEqualTo("전문가 상담이 필요해요!");
+  }
+
+  @Test
+  @DisplayName("NONE 레벨의 일간 리포트는 null을 반환한다")
+  void givenNoneLevel_whenMapDaily_thenReturnNull() {
+    // given
+    DailyToiletReport dailyReport = createDailyReport(ToiletEvaluationLevel.NONE, 0, List.of());
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("여러 기록 아이템이 있는 일간 리포트를 올바르게 매핑한다")
+  void givenMultipleItems_whenMapDaily_thenReturnCorrectReport() {
+    // given
+    ToiletEvaluation item1 =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.BANANA,
+            5,
+            1,
+            "morning");
+    ToiletEvaluation item2 =
+        createMockToiletEvaluation(
+            ActivityAt.of(LocalDate.of(2024, 1, 1)),
+            ToiletColor.DARK_BROWN,
+            ToiletShape.CORN,
+            4,
+            2,
+            "afternoon");
+    DailyToiletReport dailyReport =
+        createDailyReport(ToiletEvaluationLevel.GOOD, 85, List.of(item1, item2));
+
+    // when
+    DailyToiletReportDto result = mapper.mapDaily(dailyReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().get(0).note()).isEqualTo("morning");
+    assertThat(result.items().get(1).note()).isEqualTo("afternoon");
+  }
+
+  @Test
+  @DisplayName("VERY_GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenVeryGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.VERY_GOOD);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_very_good.png");
+    assertThat(result.backgroundColors()).containsExactly("#0C7C30", "#7DD357");
+  }
+
+  @Test
+  @DisplayName("GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.GOOD);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_good.png");
+    assertThat(result.backgroundColors()).containsExactly("#134DB1", "#588DFF");
+  }
+
+  @Test
+  @DisplayName("AVERAGE 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenAverageLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.AVERAGE);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_medium.png");
+    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+
+  @Test
+  @DisplayName("BAD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.BAD);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_bad.png");
+    assertThat(result.backgroundColors()).containsExactly("#DD5612", "#F6A85F");
+  }
+
+  @Test
+  @DisplayName("VERY_BAD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenVeryBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.VERY_BAD);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_very_bad.png");
+    assertThat(result.backgroundColors()).containsExactly("#A4141E", "#FF535F");
+  }
+
+  @Test
+  @DisplayName("NONE 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
+  void givenNoneLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.NONE);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_medium.png");
+    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+
+  @Test
+  @DisplayName("null 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
+  void givenNullLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
+    // when
+    ToiletHeroAssets result = mapper.heroAssetsByLevel(null);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.image())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/colon_medium.png");
+    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+
+  // Helper methods
+  private ToiletEvaluation createMockToiletEvaluation(
+      ActivityAt occurredAt,
+      ToiletColor color,
+      ToiletShape shape,
+      int duration,
+      double pain,
+      String note) {
+    ToiletEvaluation mock = mock(ToiletEvaluation.class);
+    when(mock.getOccurredAt()).thenReturn(occurredAt);
+    when(mock.getColor()).thenReturn(color);
+    when(mock.getShape()).thenReturn(shape);
+    when(mock.getDuration()).thenReturn(duration);
+    when(mock.getPain()).thenReturn(pain);
+    when(mock.getNote()).thenReturn(note);
+    return mock;
+  }
+
+  private DailyToiletReport createDailyReport(
+      ToiletEvaluationLevel level, double score, List<ToiletEvaluation> items) {
+    DailyToiletReport mock = mock(DailyToiletReport.class);
+    when(mock.getLevel()).thenReturn(level);
+    when(mock.getToiletScore()).thenReturn(score);
+    when(mock.getItems()).thenReturn(items);
+    return mock;
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
@@ -96,7 +96,7 @@ class ToiletReportMapperDailyTest {
         createMockToiletEvaluation(
             ActivityAt.of(LocalDate.of(2024, 1, 1)),
             ToiletColor.DARK_BROWN,
-            ToiletShape.ROCK,
+            ToiletShape.CORN,
             5,
             3,
             "average");

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperPainTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperPainTest.java
@@ -1,0 +1,213 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyPainSection;
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyPainSection.ToiletPainComparison;
+import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPainDistribution;
+
+class ToiletReportMapperPainTest {
+
+  private ToiletReportMapper mapper;
+  private MonthlyReport mockReport;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+    mockReport = mock(MonthlyReport.class);
+  }
+
+  @Test
+  @DisplayName("통증 분포를 올바르게 매핑한다")
+  void givenPainDistribution_whenMapPain_thenReturnCorrectSection() {
+    // given
+    ToiletPainDistribution distribution = new ToiletPainDistribution(5, 8, 6, 4, 2, 3);
+    when(mockReport.getToiletPainDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyPainSection result = mapper.mapPain(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 배를 부여잡은 날들이\n6회 있었어요");
+    assertThat(result.veryLow()).isEqualTo(5);
+    assertThat(result.low()).isEqualTo(8);
+    assertThat(result.medium()).isEqualTo(6);
+    assertThat(result.high()).isEqualTo(4);
+    assertThat(result.veryHigh()).isEqualTo(2);
+    assertThat(result.comparison()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("통증이 증가했을 때 increased 상태를 반환한다")
+  void givenIncreasedPain_whenFromPainDiff_thenReturnIncreasedComparison() {
+    // given
+    int painDiff = 5;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("increased");
+    assertThat(result.count()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("통증이 감소했을 때 decreased 상태를 반환한다")
+  void givenDecreasedPain_whenFromPainDiff_thenReturnDecreasedComparison() {
+    // given
+    int painDiff = -3;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("decreased");
+    assertThat(result.count()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("통증이 동일할 때 same 상태를 반환한다")
+  void givenSamePain_whenFromPainDiff_thenReturnSameComparison() {
+    // given
+    int painDiff = 0;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("same");
+    assertThat(result.count()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("통증이 큰 폭으로 증가했을 때 올바르게 처리한다")
+  void givenLargeIncrease_whenFromPainDiff_thenReturnCorrectComparison() {
+    // given
+    int painDiff = 15;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("increased");
+    assertThat(result.count()).isEqualTo(15);
+  }
+
+  @Test
+  @DisplayName("통증이 큰 폭으로 감소했을 때 올바르게 처리한다")
+  void givenLargeDecrease_whenFromPainDiff_thenReturnCorrectComparison() {
+    // given
+    int painDiff = -12;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("decreased");
+    assertThat(result.count()).isEqualTo(12);
+  }
+
+  @Test
+  @DisplayName("통증이 없는 경우를 올바르게 처리한다")
+  void givenNoPain_whenMapPain_thenReturnCorrectSection() {
+    // given
+    ToiletPainDistribution distribution = new ToiletPainDistribution(25, 0, 0, 0, 0, 0);
+    when(mockReport.getToiletPainDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyPainSection result = mapper.mapPain(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 배를 부여잡은 날들이\n0회 있었어요");
+    assertThat(result.veryLow()).isEqualTo(25);
+    assertThat(result.low()).isEqualTo(0);
+    assertThat(result.medium()).isEqualTo(0);
+    assertThat(result.high()).isEqualTo(0);
+    assertThat(result.veryHigh()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("매우 높은 통증만 있는 경우를 올바르게 처리한다")
+  void givenOnlyVeryHighPain_whenMapPain_thenReturnCorrectSection() {
+    // given
+    ToiletPainDistribution distribution = new ToiletPainDistribution(0, 0, 0, 0, 15, 15);
+    when(mockReport.getToiletPainDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyPainSection result = mapper.mapPain(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 배를 부여잡은 날들이\n15회 있었어요");
+    assertThat(result.veryLow()).isEqualTo(0);
+    assertThat(result.low()).isEqualTo(0);
+    assertThat(result.medium()).isEqualTo(0);
+    assertThat(result.high()).isEqualTo(0);
+    assertThat(result.veryHigh()).isEqualTo(15);
+  }
+
+  @Test
+  @DisplayName("균등한 통증 분포를 올바르게 처리한다")
+  void givenEvenDistribution_whenMapPain_thenReturnCorrectSection() {
+    // given
+    ToiletPainDistribution distribution = new ToiletPainDistribution(5, 5, 5, 5, 5, 10);
+    when(mockReport.getToiletPainDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyPainSection result = mapper.mapPain(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 배를 부여잡은 날들이\n10회 있었어요");
+    assertThat(result.veryLow()).isEqualTo(5);
+    assertThat(result.low()).isEqualTo(5);
+    assertThat(result.medium()).isEqualTo(5);
+    assertThat(result.high()).isEqualTo(5);
+    assertThat(result.veryHigh()).isEqualTo(5);
+    assertThat(result.comparison()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("통증 차이가 1일 때 올바르게 처리한다")
+  void givenPainDiffOfOne_whenFromPainDiff_thenReturnCorrectComparison() {
+    // given
+    int painDiff = 1;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("increased");
+    assertThat(result.count()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("통증 차이가 -1일 때 올바르게 처리한다")
+  void givenPainDiffOfMinusOne_whenFromPainDiff_thenReturnCorrectComparison() {
+    // given
+    int painDiff = -1;
+
+    // when
+    ToiletPainComparison result = mapper.fromPainDiff(painDiff);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.direction()).isEqualTo("decreased");
+    assertThat(result.count()).isEqualTo(1);
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperPeriodTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperPeriodTest.java
@@ -1,0 +1,237 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyPeriodSection;
+import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DayPeriod;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPeriodCount;
+
+class ToiletReportMapperPeriodTest {
+
+  private ToiletReportMapper mapper;
+  private MonthlyReport mockReport;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+    mockReport = mock(MonthlyReport.class);
+  }
+
+  @Test
+  @DisplayName("아침 시간대가 가장 많을 때 올바르게 매핑한다")
+  void givenMorningMostFrequent_whenMapPeriodSection_thenReturnCorrectSection() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 15),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 8),
+            new ToiletPeriodCount(DayPeriod.EVENING, 7));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).period()).isEqualTo("오전");
+    assertThat(result.items().get(0).count()).isEqualTo(15);
+  }
+
+  @Test
+  @DisplayName("오후 시간대가 가장 많을 때 올바르게 매핑한다")
+  void givenAfternoonMostFrequent_whenMapPeriodSection_thenReturnCorrectSection() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 18),
+            new ToiletPeriodCount(DayPeriod.MORNING, 10),
+            new ToiletPeriodCount(DayPeriod.EVENING, 6));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오후에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).period()).isEqualTo("오후");
+    assertThat(result.items().get(0).count()).isEqualTo(18);
+  }
+
+  @Test
+  @DisplayName("저녁 시간대가 가장 많을 때 올바르게 매핑한다")
+  void givenEveningMostFrequent_whenMapPeriodSection_thenReturnCorrectSection() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.EVENING, 20),
+            new ToiletPeriodCount(DayPeriod.MORNING, 9),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 7));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n저녁에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).period()).isEqualTo("저녁");
+    assertThat(result.items().get(0).count()).isEqualTo(20);
+  }
+
+  @Test
+  @DisplayName("가장 많은 시간대와 두 번째 시간대가 동일한 빈도일 때 올바르게 매핑한다")
+  void givenTwoPeriodsWithSameFrequency_whenMapPeriodSection_thenReturnBothInTitle() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 12),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 12),
+            new ToiletPeriodCount(DayPeriod.EVENING, 6));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전,오후에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("가장 많은 시간대와 마지막 시간대가 동일한 빈도일 때 올바르게 매핑한다")
+  void givenFirstAndLastPeriodsWithSameFrequency_whenMapPeriodSection_thenReturnBothInTitle() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 10),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 5),
+            new ToiletPeriodCount(DayPeriod.EVENING, 10));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전,저녁에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("모든 시간대가 동일한 빈도일 때 올바르게 매핑한다")
+  void givenAllPeriodsWithSameFrequency_whenMapPeriodSection_thenReturnAllInTitle() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 10),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 10),
+            new ToiletPeriodCount(DayPeriod.EVENING, 10));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전,오후,저녁에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("시간대별 빈도가 크게 차이날 때 올바르게 매핑한다")
+  void givenLargeDifferenceInFrequency_whenMapPeriodSection_thenReturnCorrectly() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 25),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 3),
+            new ToiletPeriodCount(DayPeriod.EVENING, 2));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).count()).isEqualTo(25);
+    assertThat(result.items().get(1).count()).isEqualTo(3);
+    assertThat(result.items().get(2).count()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("단일 시간대만 있을 때 올바르게 매핑한다")
+  void givenSinglePeriod_whenMapPeriodSection_thenReturnCorrectly() {
+    // given
+    List<ToiletPeriodCount> periods = List.of(new ToiletPeriodCount(DayPeriod.MORNING, 30));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).contains("오전");
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).period()).isEqualTo("오전");
+    assertThat(result.items().get(0).count()).isEqualTo(30);
+  }
+
+  @Test
+  @DisplayName("두 개의 시간대만 있을 때 올바르게 매핑한다")
+  void givenTwoPeriods_whenMapPeriodSection_thenReturnCorrectly() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 18),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 12));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전에 성공했어요");
+    assertThat(result.items()).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("빈도가 0인 시간대가 있을 때 올바르게 매핑한다")
+  void givenPeriodWithZeroCount_whenMapPeriodSection_thenReturnCorrectly() {
+    // given
+    List<ToiletPeriodCount> periods =
+        List.of(
+            new ToiletPeriodCount(DayPeriod.MORNING, 20),
+            new ToiletPeriodCount(DayPeriod.AFTERNOON, 0),
+            new ToiletPeriodCount(DayPeriod.EVENING, 10));
+    when(mockReport.getToiletPeriodCounts()).thenReturn(periods);
+
+    // when
+    MonthlyPeriodSection result = mapper.mapPeriodSection(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 주로\n오전에 성공했어요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).count()).isEqualTo(20);
+    assertThat(result.items().get(1).count()).isEqualTo(0);
+    assertThat(result.items().get(2).count()).isEqualTo(10);
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperShapeTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperShapeTest.java
@@ -1,0 +1,226 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyShapeSection;
+import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletShapeCount;
+import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
+
+class ToiletReportMapperShapeTest {
+
+  private ToiletReportMapper mapper;
+  private MonthlyReport mockReport;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+    mockReport = mock(MonthlyReport.class);
+  }
+
+  @Test
+  @DisplayName("토끼똥 모양이 가장 많을 때 '변비 주의' 메시지를 포함한다")
+  void givenRabbitShapeMostFrequent_whenMapShape_thenReturnWithConstipationWarning() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.RABBIT, 10),
+            new ToiletShapeCount(ToiletShape.BANANA, 5),
+            new ToiletShapeCount(ToiletShape.CORN, 3));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달 자주 본 배변 모양이에요");
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items().get(0).shape()).isEqualTo("RABBIT");
+    assertThat(result.items().get(0).count()).isEqualTo(10);
+    assertThat(result.items().get(0).message()).isEqualTo("변비 주의");
+  }
+
+  @Test
+  @DisplayName("바나나 모양이 가장 많을 때 빈 메시지를 포함한다")
+  void givenBananaShapeMostFrequent_whenMapShape_thenReturnWithEmptyMessage() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.BANANA, 12),
+            new ToiletShapeCount(ToiletShape.CORN, 7),
+            new ToiletShapeCount(ToiletShape.RABBIT, 5));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("BANANA");
+    assertThat(result.items().get(0).count()).isEqualTo(12);
+    assertThat(result.items().get(0).message()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("옥수수 모양이 가장 많을 때 '수분 충전 필요' 메시지를 포함한다")
+  void givenCornShapeMostFrequent_whenMapShape_thenReturnWithHydrationWarning() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.CORN, 15),
+            new ToiletShapeCount(ToiletShape.BANANA, 8),
+            new ToiletShapeCount(ToiletShape.RABBIT, 6));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("CORN");
+    assertThat(result.items().get(0).count()).isEqualTo(15);
+    assertThat(result.items().get(0).message()).isEqualTo("수분 충전 필요");
+  }
+
+  @Test
+  @DisplayName("크림 모양이 가장 많을 때 '설사 주의' 메시지를 포함한다")
+  void givenCreamShapeMostFrequent_whenMapShape_thenReturnWithDiarrheaWarning() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.CREAM, 11),
+            new ToiletShapeCount(ToiletShape.BANANA, 6),
+            new ToiletShapeCount(ToiletShape.CORN, 4));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("CREAM");
+    assertThat(result.items().get(0).count()).isEqualTo(11);
+    assertThat(result.items().get(0).message()).isEqualTo("설사 주의");
+  }
+
+  @Test
+  @DisplayName("죽 모양이 가장 많을 때 '설사 주의' 메시지를 포함한다")
+  void givenPorridgeShapeMostFrequent_whenMapShape_thenReturnWithDiarrheaWarning() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.PORRIDGE, 9),
+            new ToiletShapeCount(ToiletShape.BANANA, 5),
+            new ToiletShapeCount(ToiletShape.CORN, 3));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("PORRIDGE");
+    assertThat(result.items().get(0).count()).isEqualTo(9);
+    assertThat(result.items().get(0).message()).isEqualTo("설사 주의");
+  }
+
+  @Test
+  @DisplayName("물 모양이 가장 많을 때 '설사 주의' 메시지를 포함한다")
+  void givenWaterShapeMostFrequent_whenMapShape_thenReturnWithDiarrheaWarning() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.WATER, 13),
+            new ToiletShapeCount(ToiletShape.BANANA, 7),
+            new ToiletShapeCount(ToiletShape.CORN, 5));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("WATER");
+    assertThat(result.items().get(0).count()).isEqualTo(13);
+    assertThat(result.items().get(0).message()).isEqualTo("설사 주의");
+  }
+
+  @Test
+  @DisplayName("바위 모양이 가장 많을 때 빈 메시지를 포함한다")
+  void givenRockShapeMostFrequent_whenMapShape_thenReturnWithEmptyMessage() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.ROCK, 8),
+            new ToiletShapeCount(ToiletShape.BANANA, 6),
+            new ToiletShapeCount(ToiletShape.CORN, 4));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items().get(0).shape()).isEqualTo("ROCK");
+    assertThat(result.items().get(0).count()).isEqualTo(8);
+    assertThat(result.items().get(0).message()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("여러 모양이 있을 때 모든 모양을 올바르게 매핑한다")
+  void givenMultipleShapes_whenMapShape_thenReturnAllShapesCorrectly() {
+    // given
+    List<ToiletShapeCount> shapes =
+        List.of(
+            new ToiletShapeCount(ToiletShape.BANANA, 15),
+            new ToiletShapeCount(ToiletShape.RABBIT, 12),
+            new ToiletShapeCount(ToiletShape.CORN, 10),
+            new ToiletShapeCount(ToiletShape.CREAM, 8),
+            new ToiletShapeCount(ToiletShape.WATER, 5));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달 자주 본 배변 모양이에요");
+    assertThat(result.items()).hasSize(5);
+    assertThat(result.items().get(0).shape()).isEqualTo("BANANA");
+    assertThat(result.items().get(0).message()).isEmpty();
+    assertThat(result.items().get(1).shape()).isEqualTo("RABBIT");
+    assertThat(result.items().get(1).message()).isEqualTo("변비 주의");
+    assertThat(result.items().get(2).shape()).isEqualTo("CORN");
+    assertThat(result.items().get(2).message()).isEqualTo("수분 충전 필요");
+    assertThat(result.items().get(3).shape()).isEqualTo("CREAM");
+    assertThat(result.items().get(3).message()).isEqualTo("설사 주의");
+    assertThat(result.items().get(4).shape()).isEqualTo("WATER");
+    assertThat(result.items().get(4).message()).isEqualTo("설사 주의");
+  }
+
+  @Test
+  @DisplayName("단일 모양만 있을 때도 올바르게 매핑한다")
+  void givenSingleShape_whenMapShape_thenReturnCorrectly() {
+    // given
+    List<ToiletShapeCount> shapes = List.of(new ToiletShapeCount(ToiletShape.BANANA, 20));
+    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
+
+    // when
+    MonthlyShapeSection result = mapper.mapShape(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().get(0).shape()).isEqualTo("BANANA");
+    assertThat(result.items().get(0).count()).isEqualTo(20);
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperShapeTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperShapeTest.java
@@ -155,27 +155,6 @@ class ToiletReportMapperShapeTest {
   }
 
   @Test
-  @DisplayName("바위 모양이 가장 많을 때 빈 메시지를 포함한다")
-  void givenRockShapeMostFrequent_whenMapShape_thenReturnWithEmptyMessage() {
-    // given
-    List<ToiletShapeCount> shapes =
-        List.of(
-            new ToiletShapeCount(ToiletShape.ROCK, 8),
-            new ToiletShapeCount(ToiletShape.BANANA, 6),
-            new ToiletShapeCount(ToiletShape.CORN, 4));
-    when(mockReport.getMostFrequentToiletShapes()).thenReturn(shapes);
-
-    // when
-    MonthlyShapeSection result = mapper.mapShape(mockReport);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.items().get(0).shape()).isEqualTo("ROCK");
-    assertThat(result.items().get(0).count()).isEqualTo(8);
-    assertThat(result.items().get(0).message()).isEmpty();
-  }
-
-  @Test
   @DisplayName("여러 모양이 있을 때 모든 모양을 올바르게 매핑한다")
   void givenMultipleShapes_whenMapShape_thenReturnAllShapesCorrectly() {
     // given

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperTimeDistributionTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperTimeDistributionTest.java
@@ -1,0 +1,251 @@
+package depromeet.lessonfour.server.report.api.mapper.toilet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyTimeDistributionSection;
+import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletTimeDistribution;
+
+class ToiletReportMapperTimeDistributionTest {
+
+  private ToiletReportMapper mapper;
+  private MonthlyReport mockReport;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ToiletReportMapper();
+    mockReport = mock(MonthlyReport.class);
+  }
+
+  @Test
+  @DisplayName("5분 이내가 가장 많을 때 올바른 메시지를 반환한다")
+  void givenWithin5MinMostFrequent_whenMapTimeDistribution_thenReturnCorrectMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(15, 8, 5);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 5분 이내였어요");
+    assertThat(result.within5min()).isEqualTo(15);
+    assertThat(result.over5min()).isEqualTo(8);
+    assertThat(result.over10min()).isEqualTo(5);
+    assertThat(result.warning()).isNull();
+  }
+
+  @Test
+  @DisplayName("5분 이상이 가장 많을 때 올바른 메시지를 반환한다")
+  void givenOver5MinMostFrequent_whenMapTimeDistribution_thenReturnCorrectMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(8, 18, 6);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 5분 이상이었어요");
+    assertThat(result.within5min()).isEqualTo(8);
+    assertThat(result.over5min()).isEqualTo(18);
+    assertThat(result.over10min()).isEqualTo(6);
+    assertThat(result.warning()).isNull();
+  }
+
+  @Test
+  @DisplayName("10분 이상이 가장 많을 때 경고 메시지를 포함한다")
+  void givenOver10MinMostFrequent_whenMapTimeDistribution_thenReturnWithWarning() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(7, 9, 20);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 10분 이상이었어요");
+    assertThat(result.within5min()).isEqualTo(7);
+    assertThat(result.over5min()).isEqualTo(9);
+    assertThat(result.over10min()).isEqualTo(20);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("모든 시간대가 동일한 빈도일 때 올바른 메시지를 반환한다")
+  void givenAllTimesEqual_whenMapTimeDistribution_thenReturnVariedMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(10, 10, 10);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 화장실에서\n보낸 시간이 매번 달랐어요");
+    assertThat(result.within5min()).isEqualTo(10);
+    assertThat(result.over5min()).isEqualTo(10);
+    assertThat(result.over10min()).isEqualTo(10);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("두 개의 시간대가 동일한 빈도일 때 올바른 메시지를 반환한다")
+  void givenTwoTimesEqual_whenMapTimeDistribution_thenReturnMixedMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(12, 12, 5);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 화장실에서\n짧고 긴 시간 모두를 경험했어요");
+    assertThat(result.within5min()).isEqualTo(12);
+    assertThat(result.over5min()).isEqualTo(12);
+    assertThat(result.over10min()).isEqualTo(5);
+    assertThat(result.warning()).isNull();
+  }
+
+  @Test
+  @DisplayName("5분 이내와 10분 이상이 동일한 빈도일 때 올바른 메시지를 반환한다")
+  void givenWithin5AndOver10Equal_whenMapTimeDistribution_thenReturnMixedMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(15, 8, 15);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 화장실에서\n짧고 긴 시간 모두를 경험했어요");
+    assertThat(result.within5min()).isEqualTo(15);
+    assertThat(result.over5min()).isEqualTo(8);
+    assertThat(result.over10min()).isEqualTo(15);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("5분 이상과 10분 이상이 동일한 빈도일 때 올바른 메시지를 반환한다")
+  void givenOver5AndOver10Equal_whenMapTimeDistribution_thenReturnMixedMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(7, 14, 14);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 화장실에서\n짧고 긴 시간 모두를 경험했어요");
+    assertThat(result.within5min()).isEqualTo(7);
+    assertThat(result.over5min()).isEqualTo(14);
+    assertThat(result.over10min()).isEqualTo(14);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("5분 이내만 있을 때 올바르게 처리한다")
+  void givenOnlyWithin5Min_whenMapTimeDistribution_thenReturnCorrectly() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(30, 0, 0);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 5분 이내였어요");
+    assertThat(result.within5min()).isEqualTo(30);
+    assertThat(result.over5min()).isEqualTo(0);
+    assertThat(result.over10min()).isEqualTo(0);
+    assertThat(result.warning()).isNull();
+  }
+
+  @Test
+  @DisplayName("10분 이상만 있을 때 경고 메시지를 포함한다")
+  void givenOnlyOver10Min_whenMapTimeDistribution_thenReturnWithWarning() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(0, 0, 25);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 10분 이상이었어요");
+    assertThat(result.within5min()).isEqualTo(0);
+    assertThat(result.over5min()).isEqualTo(0);
+    assertThat(result.over10min()).isEqualTo(25);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("큰 빈도 차이가 있을 때 올바르게 처리한다")
+  void givenLargeDifference_whenMapTimeDistribution_thenReturnCorrectly() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(50, 3, 2);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 5분 이내였어요");
+    assertThat(result.within5min()).isEqualTo(50);
+    assertThat(result.over5min()).isEqualTo(3);
+    assertThat(result.over10min()).isEqualTo(2);
+    assertThat(result.warning()).isNull();
+  }
+
+  @Test
+  @DisplayName("작은 빈도수들로도 올바르게 처리한다")
+  void givenSmallNumbers_whenMapTimeDistribution_thenReturnCorrectly() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(1, 2, 3);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("배변 소요 시간은\n주로 10분 이상이었어요");
+    assertThat(result.within5min()).isEqualTo(1);
+    assertThat(result.over5min()).isEqualTo(2);
+    assertThat(result.over10min()).isEqualTo(3);
+    assertThat(result.warning()).isEqualTo("소요 시간이 10분이 넘으면 변비 · 치질 위험도가 올라가요");
+  }
+
+  @Test
+  @DisplayName("5분 이내와 5분 이상이 동일하고 10분 이상이 다를 때 올바르게 처리한다")
+  void
+      givenWithin5AndOver5EqualButOver10Different_whenMapTimeDistribution_thenReturnMixedMessage() {
+    // given
+    ToiletTimeDistribution distribution = new ToiletTimeDistribution(10, 10, 5);
+    when(mockReport.getToiletTimeDistribution()).thenReturn(distribution);
+
+    // when
+    MonthlyTimeDistributionSection result = mapper.mapTimeDistribution(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달은 화장실에서\n짧고 긴 시간 모두를 경험했어요");
+    assertThat(result.warning()).isNull();
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/toiletrecord/api/CreateToiletRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/toiletrecord/api/CreateToiletRecordE2ETest.java
@@ -496,7 +496,7 @@ class CreateToiletRecordE2ETest {
   @DisplayName("모든 형태 타입으로 요청시 성공한다")
   void givenAllShapeTypes_whenCreateToiletRecord_thenSuccess() {
     LocalDateTime now = LocalDateTime.now();
-    String[] shapes = {"RABBIT", "ROCK", "CORN", "BANANA", "CREAM", "PORRIDGE"};
+    String[] shapes = {"RABBIT", "CORN", "BANANA", "CREAM", "PORRIDGE", "WATER"};
 
     for (String shape : shapes) {
       String createRequest =

--- a/src/test/java/depromeet/lessonfour/server/toiletrecord/api/UpdateToiletRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/toiletrecord/api/UpdateToiletRecordE2ETest.java
@@ -111,7 +111,7 @@ class UpdateToiletRecordE2ETest {
         {
           "isSuccessful": false,
           "color": "RED",
-          "shape": "ROCK",
+          "shape": "CORN",
           "pain": 50,
           "duration": 12,
           "note": "수정된 배변 기록"
@@ -132,7 +132,7 @@ class UpdateToiletRecordE2ETest {
         .body("data.id", equalTo(toiletRecordId.intValue()))
         .body("data.isSuccessful", equalTo(false))
         .body("data.color", equalTo("RED"))
-        .body("data.shape", equalTo("ROCK"))
+        .body("data.shape", equalTo("CORN"))
         .body("data.pain", equalTo(50))
         .body("data.duration", equalTo(12))
         .body("data.note", equalTo("수정된 배변 기록"));
@@ -563,7 +563,7 @@ class UpdateToiletRecordE2ETest {
   @Test
   @DisplayName("모든 형태 타입으로 수정 가능하다")
   void givenAllShapeTypes_whenUpdateToiletRecord_thenSuccess() {
-    String[] shapes = {"RABBIT", "ROCK", "CORN", "BANANA", "CREAM", "PORRIDGE"};
+    String[] shapes = {"RABBIT", "WATER", "CORN", "BANANA", "CREAM", "PORRIDGE"};
 
     for (String shape : shapes) {
       // 배변기록 생성
@@ -650,7 +650,7 @@ class UpdateToiletRecordE2ETest {
         {
           "isSuccessful": false,
           "color": "RED",
-          "shape": "ROCK",
+          "shape": "RABBIT",
           "pain": 80
         }
         """;

--- a/src/test/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordQueryTest.java
+++ b/src/test/java/depromeet/lessonfour/server/toiletrecord/infra/repository/ToiletRecordQueryTest.java
@@ -255,7 +255,7 @@ class ToiletRecordQueryTest {
     ToiletRecord midnight =
         createToiletRecord(testUser, today.atTime(0, 0), ToiletColor.DARK_BROWN, ToiletShape.CORN);
     ToiletRecord almostMidnight =
-        createToiletRecord(testUser, today.atTime(23, 59), ToiletColor.RED, ToiletShape.ROCK);
+        createToiletRecord(testUser, today.atTime(23, 59), ToiletColor.RED, ToiletShape.CORN);
 
     ActivityAt activityAt = ActivityAt.of(today);
 


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 월간 리포트 생성시 ToiletShape, ToiletColor의 value값이 전달되는 에러 수정
* 사용하지 않는 ToiletShape.ROCK 제거
* 월간 리포트 생성 시 색상 우선순위가 적용되도록 수정

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 색상 우선순위 기반 정렬로 월간 보고서에서 대표 색상 선택 개선

* **버그 수정**
  * 색상 데이터 누락 시 명확한 오류 응답(서버 오류) 처리 강화
  * 색상 문자열 표기 방식 변경(내부 표현 방식 갱신)

* **변경 사항**
  * 배변 모양 옵션에서 "바위(ROCK)" 제거

* **테스트**
  * 색상·일간·주간 매핑 및 다양한 매핑 로직에 대한 포괄적 단위·E2E 테스트 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->