### PR TITLE
Fix/일간 리포트 음식 기록 날짜 불일치 오류 해결

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
@@ -48,8 +48,11 @@ public class ReportController {
   public SuccessResponse<GetDailyReportResponseDto> getDailyReport(
       @AuthenticationPrincipal(expression = "id") Long userId,
       @RequestParam(required = false) LocalDateTime dateTime) {
+
     LocalDateTime baseDateTime = (dateTime != null) ? dateTime : LocalDateTime.now(clock);
+
     DailyReport dailyReport = getDailyReportUseCase.getDailyReport(userId, baseDateTime);
+
     return SuccessResponse.of(
         SuccessCode.SUCCESS_FETCH, dailyReportMapper.map(dailyReport, baseDateTime));
   }
@@ -59,7 +62,9 @@ public class ReportController {
   public SuccessResponse<GetWeeklyReportResponseDto> getWeeklyReport(
       @AuthenticationPrincipal(expression = "id") Long userId,
       @RequestParam(required = false) LocalDateTime dateTime) {
+
     LocalDateTime baseDateTime = (dateTime != null) ? dateTime : LocalDateTime.now(clock);
+
     WeeklyReport weeklyReport = weeklyReportUseCase.generateWeeklyReport(userId, baseDateTime);
     return SuccessResponse.of(
         SuccessCode.SUCCESS_FETCH, weeklyReportMapper.map(weeklyReport, baseDateTime));
@@ -70,6 +75,7 @@ public class ReportController {
   public SuccessResponse<GetMonthlyReportResponseDto> generateMonthlyReport(
       @AuthenticationPrincipal(expression = "id") Long userId,
       @RequestParam(required = false) YearMonth yearMonth) {
+
     YearMonth baseMonth = (yearMonth != null) ? yearMonth : YearMonth.now(clock);
 
     MonthlyReport monthlyReport = monthlyReportUseCase.generateMonthlyReport(userId, baseMonth);

--- a/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/controller/ReportController.java
@@ -19,7 +19,7 @@ import depromeet.lessonfour.server.report.api.dto.response.GetWeeklyReportRespon
 import depromeet.lessonfour.server.report.api.mapper.DailyReportMapper;
 import depromeet.lessonfour.server.report.api.mapper.MonthlyReportMapper;
 import depromeet.lessonfour.server.report.api.mapper.WeeklyReportMapper;
-import depromeet.lessonfour.server.report.app.service.GetDailyReportUseCase;
+import depromeet.lessonfour.server.report.app.service.DailyReportUseCase;
 import depromeet.lessonfour.server.report.app.service.MonthlyReportUseCase;
 import depromeet.lessonfour.server.report.app.service.WeeklyReportUseCase;
 import depromeet.lessonfour.server.report.domain.vo.DailyReport;
@@ -35,9 +35,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReportController {
 
-  private final GetDailyReportUseCase getDailyReportUseCase;
+  private final DailyReportUseCase dailyReportUseCase;
   private final WeeklyReportUseCase weeklyReportUseCase;
   private final MonthlyReportUseCase monthlyReportUseCase;
+
   private final DailyReportMapper dailyReportMapper;
   private final WeeklyReportMapper weeklyReportMapper;
   private final MonthlyReportMapper monthlyReportMapper;
@@ -51,7 +52,7 @@ public class ReportController {
 
     LocalDateTime baseDateTime = (dateTime != null) ? dateTime : LocalDateTime.now(clock);
 
-    DailyReport dailyReport = getDailyReportUseCase.getDailyReport(userId, baseDateTime);
+    DailyReport dailyReport = dailyReportUseCase.getDailyReport(userId, baseDateTime);
 
     return SuccessResponse.of(
         SuccessCode.SUCCESS_FETCH, dailyReportMapper.map(dailyReport, baseDateTime));

--- a/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetDailyReportResponseDto.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/dto/response/GetDailyReportResponseDto.java
@@ -1,5 +1,6 @@
 package depromeet.lessonfour.server.report.api.dto.response;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -34,7 +35,7 @@ public record GetDailyReportResponseDto(
   // FOOD
   public record DailyFoodReport(String message, List<FoodReportItem> items) {}
 
-  public record FoodReportItem(LocalDateTime occurredAt, List<DailyFoodReportMeal> meals) {}
+  public record FoodReportItem(LocalDate occurredAt, List<DailyFoodReportMeal> meals) {}
 
   public record DailyFoodReportMeal(MealTime mealTime, boolean dangerous, List<String> foods) {}
 

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/DailyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/DailyReportMapper.java
@@ -21,11 +21,11 @@ public class DailyReportMapper {
   private final WaterMapper waterMapper;
   private final StressMapper stressMapper;
 
-  public GetDailyReportResponseDto map(DailyReport dailyReport, LocalDateTime updatedAt) {
+  public GetDailyReportResponseDto map(DailyReport dailyReport, LocalDateTime baseDateTime) {
     return new GetDailyReportResponseDto(
-        updatedAt,
+        baseDateTime,
         toiletReportMapper.mapDaily(dailyReport.dailyToiletReport()),
-        foodMapper.mapDaily(dailyReport.dailyActivityReport().getFoodEvaluations()),
+        foodMapper.mapDaily(dailyReport.dailyActivityReport().getFoodEvaluations(), baseDateTime),
         waterMapper.mapDaily(dailyReport.dailyActivityReport().getWaterEvaluations()),
         stressMapper.mapDaily(dailyReport.dailyActivityReport().getStressEvaluation()));
   }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
@@ -37,11 +37,16 @@ public class FoodMapper {
   private final Clock clock;
 
   /** 일간 음식 보고서 매핑 */
-  public DailyFoodReport mapDaily(List<FoodEvaluation> foodEvaluations) {
+  public DailyFoodReport mapDaily(
+      List<FoodEvaluation> foodEvaluations, LocalDateTime baseDateTime) {
     String message = getMessage(foodEvaluations);
+    LocalDate baseDate = baseDateTime.toLocalDate();
+    LocalDate dayBefore = baseDate.minusDays(1);
 
     List<FoodReportItem> items =
-        foodEvaluations.stream().map(this::createFoodReportItem).collect(toList());
+        foodEvaluations.stream()
+            .map(evaluation -> createFoodReportItem(evaluation, baseDate))
+            .toList();
 
     if (foodEvaluations.size() == 1) {
       FoodEvaluation evaluation = foodEvaluations.getFirst();
@@ -49,11 +54,16 @@ public class FoodMapper {
 
       if (dayType == DayType.YESTERDAY) {
         // 어제 데이터만 있는 경우: 어제 데이터 + 오늘 빈 데이터
-        items = List.of(createFoodReportItem(evaluation), createEmptyFoodReportItem(DayType.TODAY));
+        items =
+            List.of(
+                createFoodReportItem(evaluation, dayBefore),
+                createEmptyFoodReportItem(DayType.TODAY, baseDate));
       } else {
         // 오늘 데이터만 있는 경우: 어제 빈 데이터 + 오늘 데이터
         items =
-            List.of(createEmptyFoodReportItem(DayType.YESTERDAY), createFoodReportItem(evaluation));
+            List.of(
+                createEmptyFoodReportItem(DayType.YESTERDAY, dayBefore),
+                createFoodReportItem(evaluation, baseDate));
       }
     }
     // 두 날짜 모두 있는 경우는  DayType 순서로 정렬
@@ -61,8 +71,8 @@ public class FoodMapper {
       items =
           foodEvaluations.stream()
               .sorted(comparing(FoodEvaluation::getDayType))
-              .map(this::createFoodReportItem)
-              .collect(toList());
+              .map(evaluation -> createFoodReportItem(evaluation, baseDate))
+              .toList();
     }
 
     // 데이터가 없는 경우: 어제와 오늘 모두 빈 데이터
@@ -73,7 +83,7 @@ public class FoodMapper {
     return new DailyFoodReport(message, items);
   }
 
-  private FoodReportItem createFoodReportItem(FoodEvaluation foodEvaluation) {
+  private FoodReportItem createFoodReportItem(FoodEvaluation foodEvaluation, LocalDate baseDate) {
     List<DailyFoodReportMeal> meals =
         foodEvaluation.getFoodsByMealTime().entrySet().stream()
             .map(
@@ -84,17 +94,18 @@ public class FoodMapper {
                         entry.getValue()))
             .collect(toList());
 
-    return new FoodReportItem(getDate(foodEvaluation.getDayType()), meals);
+    return new FoodReportItem(getDate(foodEvaluation.getDayType(), baseDate), meals);
   }
 
-  private FoodReportItem createEmptyFoodReportItem(DayType dayType) {
-    return new FoodReportItem(getDate(dayType), List.of());
+  private FoodReportItem createEmptyFoodReportItem(DayType dayType, LocalDate baseDate) {
+    return new FoodReportItem(getDate(dayType, baseDate), List.of());
   }
 
-  private LocalDateTime getDate(DayType dateType) {
-    return dateType == DayType.YESTERDAY
-        ? LocalDateTime.now(clock).minusDays(1)
-        : LocalDateTime.now(clock);
+  private LocalDate getDate(DayType dateType, LocalDate baseDate) {
+    if (dateType == DayType.YESTERDAY) {
+      return baseDate.minusDays(1);
+    }
+    return baseDate;
   }
 
   private static String getMessage(List<FoodEvaluation> foodEvaluations) {

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
@@ -56,13 +56,13 @@ public class FoodMapper {
         // 어제 데이터만 있는 경우: 어제 데이터 + 오늘 빈 데이터
         items =
             List.of(
-                createFoodReportItem(evaluation, dayBefore),
+                createFoodReportItem(evaluation, baseDate),
                 createEmptyFoodReportItem(DayType.TODAY, baseDate));
       } else {
         // 오늘 데이터만 있는 경우: 어제 빈 데이터 + 오늘 데이터
         items =
             List.of(
-                createEmptyFoodReportItem(DayType.YESTERDAY, dayBefore),
+                createEmptyFoodReportItem(DayType.YESTERDAY, baseDate),
                 createFoodReportItem(evaluation, baseDate));
       }
     }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 @UseCase
 @Transactional
 @RequiredArgsConstructor
-public class GetDailyReportUseCase {
+public class DailyReportUseCase {
 
   private final ActivityReportService activityReportService;
   private final ToiletReportService toiletReportService;

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -246,4 +246,69 @@ class GetDailyReportE2ETest {
         .body("data.water", anyOf(nullValue(), notNullValue()))
         .body("data.stress", anyOf(nullValue(), notNullValue()));
   }
+
+  // 6) food 필드가 조회 날짜 기준으로 오늘/어제 데이터만 반환
+  @Test
+  @DisplayName("[E2E] food 필드는 조회 날짜(dateTime) 기준으로 오늘과 어제 데이터만 반환해야 함")
+  void
+      givenMultipleDaysActivities_whenGetDailyReportWithSpecificDate_thenFoodContainsOnlyTodayAndYesterdayData() {
+    // Given: 여러 날짜에 activity 생성
+    LocalDateTime targetDate = LocalDateTime.of(2024, 1, 20, 10, 0);
+    LocalDateTime yesterday = targetDate.minusDays(1); // 2024.1.19
+    LocalDateTime twoDaysAgo = targetDate.minusDays(2); // 2024.1.18
+    LocalDateTime tomorrow = targetDate.plusDays(1); // 2024.1.21
+
+    // 조회 날짜(2024.1.20)와 어제(2024.1.19)의 activity 생성
+    createActivity(targetDate.withHour(14));
+    createActivity(yesterday.withHour(15));
+
+    // 다른 날짜의 activity도 생성
+    createActivity(twoDaysAgo.withHour(16));
+    createActivity(tomorrow.withHour(17));
+
+    // When & Then: 2024.1.20으로 조회 시, food 필드에 2024.1.20과 2024.1.19 데이터만 포함되어야 함
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(targetDate))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)) // 오늘(1.20) + 어제(1.19) = 2개
+        .body("data.food.items[0].occurredAt", notNullValue())
+        .body("data.food.items[1].occurredAt", notNullValue());
+  }
+
+  // 7) 다른 날짜로 조회 시에도 해당 날짜 기준으로 오늘/어제 데이터 반환
+  @Test
+  @DisplayName("[E2E] 다른 날짜로 조회 시에도 해당 날짜 기준 오늘/어제 데이터만 반환")
+  void
+      givenMultipleDaysActivities_whenGetDailyReportWithDifferentDate_thenFoodContainsCorrectDateRangeData() {
+    // Given: 여러 날짜에 activity 생성
+    LocalDateTime date1 = LocalDateTime.of(2024, 1, 25, 10, 0);
+    LocalDateTime date2 = LocalDateTime.of(2024, 1, 26, 10, 0);
+    LocalDateTime date3 = LocalDateTime.of(2024, 1, 27, 10, 0);
+    LocalDateTime date4 = LocalDateTime.of(2024, 1, 28, 10, 0);
+
+    createActivity(date1);
+    createActivity(date2);
+    createActivity(date3);
+    createActivity(date4);
+
+    // When & Then: 2024.1.27로 조회 시, food 필드에 1.27과 1.26 데이터만 포함
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(date3))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)); // 1.27 + 1.26 = 2개
+  }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -246,4 +246,67 @@ class GetDailyReportE2ETest {
         .body("data.water", anyOf(nullValue(), notNullValue()))
         .body("data.stress", anyOf(nullValue(), notNullValue()));
   }
+
+  // 6) food 필드가 조회 날짜 기준으로 오늘/어제 데이터만 반환
+  @Test
+  @DisplayName("[E2E] food 필드는 조회 날짜(dateTime) 기준으로 오늘과 어제 데이터만 반환해야 함")
+  void givenMultipleDaysActivities_whenGetDailyReportWithSpecificDate_thenFoodContainsOnlyTodayAndYesterdayData() {
+    // Given: 여러 날짜에 activity 생성
+    LocalDateTime targetDate = LocalDateTime.of(2024, 1, 20, 10, 0);
+    LocalDateTime yesterday = targetDate.minusDays(1); // 2024.1.19
+    LocalDateTime twoDaysAgo = targetDate.minusDays(2); // 2024.1.18
+    LocalDateTime tomorrow = targetDate.plusDays(1); // 2024.1.21
+
+    // 조회 날짜(2024.1.20)와 어제(2024.1.19)의 activity 생성
+    createActivity(targetDate.withHour(14));
+    createActivity(yesterday.withHour(15));
+
+    // 다른 날짜의 activity도 생성
+    createActivity(twoDaysAgo.withHour(16));
+    createActivity(tomorrow.withHour(17));
+
+    // When & Then: 2024.1.20으로 조회 시, food 필드에 2024.1.20과 2024.1.19 데이터만 포함되어야 함
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(targetDate))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)) // 오늘(1.20) + 어제(1.19) = 2개
+        .body("data.food.items[0].occurredAt", notNullValue())
+        .body("data.food.items[1].occurredAt", notNullValue());
+  }
+
+  // 7) 다른 날짜로 조회 시에도 해당 날짜 기준으로 오늘/어제 데이터 반환
+  @Test
+  @DisplayName("[E2E] 다른 날짜로 조회 시에도 해당 날짜 기준 오늘/어제 데이터만 반환")
+  void givenMultipleDaysActivities_whenGetDailyReportWithDifferentDate_thenFoodContainsCorrectDateRangeData() {
+    // Given: 여러 날짜에 activity 생성
+    LocalDateTime date1 = LocalDateTime.of(2024, 1, 25, 10, 0);
+    LocalDateTime date2 = LocalDateTime.of(2024, 1, 26, 10, 0);
+    LocalDateTime date3 = LocalDateTime.of(2024, 1, 27, 10, 0);
+    LocalDateTime date4 = LocalDateTime.of(2024, 1, 28, 10, 0);
+
+    createActivity(date1);
+    createActivity(date2);
+    createActivity(date3);
+    createActivity(date4);
+
+    // When & Then: 2024.1.27로 조회 시, food 필드에 1.27과 1.26 데이터만 포함
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(date3))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)); // 1.27 + 1.26 = 2개
+  }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -311,4 +311,55 @@ class GetDailyReportE2ETest {
         .body("data.food", notNullValue())
         .body("data.food.items.size()", equalTo(2)); // 1.27 + 1.26 = 2개
   }
+
+  // 8) 어제 데이터만 있는 경우 날짜가 정확히 반환되는지 검증
+  @Test
+  @DisplayName("[E2E] 어제 데이터만 있는 경우 날짜가 올바르게 반환되어야 함")
+  void givenOnlyYesterdayActivity_whenGetDailyReport_thenFoodItemsHaveCorrectDates() {
+    // Given: 2024.1.20 기준으로 어제(1.19)만 activity 생성
+    LocalDateTime targetDate = LocalDateTime.of(2024, 1, 20, 10, 0);
+    LocalDateTime yesterday = targetDate.minusDays(1); // 2024.1.19
+
+    createActivity(yesterday.withHour(14));
+
+    // When & Then: 2024.1.20으로 조회 시
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(targetDate))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)) // 어제 + 오늘(빈) = 2개
+        .body("data.food.items[0].occurredAt", equalTo("2024-01-19")) // 어제 날짜가 정확해야 함
+        .body("data.food.items[1].occurredAt", equalTo("2024-01-20")); // 오늘 날짜(빈 데이터)
+  }
+
+  // 9) 오늘 데이터만 있는 경우 날짜가 정확히 반환되는지 검증
+  @Test
+  @DisplayName("[E2E] 오늘 데이터만 있는 경우 날짜가 올바르게 반환되어야 함")
+  void givenOnlyTodayActivity_whenGetDailyReport_thenFoodItemsHaveCorrectDates() {
+    // Given: 2024.1.20 기준으로 오늘만 activity 생성
+    LocalDateTime targetDate = LocalDateTime.of(2024, 1, 20, 10, 0);
+
+    createActivity(targetDate.withHour(14));
+
+    // When & Then: 2024.1.20으로 조회 시
+    given()
+        .header("Authorization", validJwtToken)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+        .when()
+        .get(url(targetDate))
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body("status", equalTo(200))
+        .body("data.food", notNullValue())
+        .body("data.food.items.size()", equalTo(2)) // 어제(빈) + 오늘 = 2개
+        .body("data.food.items[0].occurredAt", equalTo("2024-01-19")) // 어제 날짜(빈 데이터)
+        .body("data.food.items[1].occurredAt", equalTo("2024-01-20")); // 오늘 날짜가 정확해야 함
+  }
 }


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 일간 리포트 생성시 음식 기록의 날짜가 요청 시간을 기준으로 보내지는 오류 수정
* 파라미터로 받은 시간을 기준으로 음식 기록의 시간이 채워지도록 수정
* 시간을 제거한 날짜만 반환하도록 수정

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 일일 보고서의 음식 데이터가 쿼리 대상 날짜와 그 전날 데이터만 정확히 반환되도록 개선했습니다.

* **Tests**
  * 일일 보고서의 날짜별 음식 데이터 필터링을 검증하는 엔드투엔드 테스트가 추가되었습니다.

* **Refactor**
  * 날짜 기준(base date) 일관성을 확보해 일일 항목 생성 및 날짜 해석이 안정적으로 동작하도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->