### PR TITLE
Refactor/일간 리포트 점수 업데이트 의존성 수정

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/app/event/ToiletRecordEventHandler.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/event/ToiletRecordEventHandler.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 import depromeet.lessonfour.server.common.domain.event.CommonEvent;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
-import depromeet.lessonfour.server.report.app.service.ToiletReportService;
+import depromeet.lessonfour.server.report.app.service.ToiletScoreUpsertUseCase;
 import depromeet.lessonfour.server.toiletrecord.app.event.ToiletRecordEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ToiletRecordEventHandler {
 
-  private final ToiletReportService toiletReportService;
+  private final ToiletScoreUpsertUseCase toiletScoreUpsertUseCase;
 
   @EventListener
   public void handle(CommonEvent<?> event) {
@@ -27,7 +27,7 @@ public class ToiletRecordEventHandler {
     ActivityAt date = payload.date();
 
     log.info("Handling ToiletRecord event - traceId: {}", event.traceId());
-    toiletReportService.generateDailyReport(userId, date);
+    toiletScoreUpsertUseCase.upsertToiletScore(userId, date);
     log.info("ToiletScore saved - traceId: {}", event.traceId());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
@@ -18,6 +18,7 @@ public class DailyReportUseCase {
 
   private final ActivityReportService activityReportService;
   private final ToiletReportService toiletReportService;
+  private final ToiletScoreService toiletScoreService;
 
   public DailyReport getDailyReport(Long userId, LocalDateTime dateTime) {
     ActivityAt activityAt = ActivityAt.of(dateTime.toLocalDate());
@@ -29,6 +30,9 @@ public class DailyReportUseCase {
     // 배변 기록 리포트 생성
     DailyToiletReport dailyToiletReport =
         toiletReportService.generateDailyReport(userId, activityAt);
+
+    // 배변 점수 업데이트
+    toiletScoreService.updateScore(userId, (int) dailyToiletReport.getToiletScore(), activityAt);
 
     return new DailyReport(dailyActivityReport, dailyToiletReport);
   }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/DailyReportUseCase.java
@@ -32,7 +32,7 @@ public class DailyReportUseCase {
         toiletReportService.generateDailyReport(userId, activityAt);
 
     // 배변 점수 업데이트
-    toiletScoreService.updateScore(userId, (int) dailyToiletReport.getToiletScore(), activityAt);
+    toiletScoreService.upsertScore(userId, (int) dailyToiletReport.getToiletScore(), activityAt);
 
     return new DailyReport(dailyActivityReport, dailyToiletReport);
   }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
@@ -18,18 +18,14 @@ import lombok.RequiredArgsConstructor;
 public class ToiletReportService {
 
   private final ToiletRecordClient toiletRecordClient;
-  private final ToiletScoreService toiletScoreService;
 
   /** 일간 배변 리포트 생성 */
   public DailyToiletReport generateDailyReport(Long userId, ActivityAt activityAt) {
+
     List<ToiletRecord> dailyRecords =
         toiletRecordClient.getToiletRecordsByActivityAt(userId, activityAt);
 
-    DailyToiletReport report = ToiletEvaluation.summarize(dailyRecords);
-
-    toiletScoreService.updateScore(userId, (int) report.getToiletScore(), activityAt);
-
-    return report;
+    return ToiletEvaluation.summarize(dailyRecords);
   }
 
   /** 주간 배변 리포트 생성 */
@@ -46,10 +42,10 @@ public class ToiletReportService {
   public MonthlyToiletReport generateMonthlyReport(
       Long userId, ActivityAt start, ActivityAt endExclusive) {
 
-    // 지난 달 통증 일수 계산
     List<ToiletRecord> lastMonthToiletRecords =
         toiletRecordClient.getToiletRecordsByActivityAtBetween(userId, start.getLastMonth(), start);
 
+    // 지난 달 통증 일수 계산
     long lastMonthPainfulDays =
         lastMonthToiletRecords.stream().filter(ToiletRecord::isPainful).count();
 

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreService.java
@@ -31,7 +31,7 @@ public class ToiletScoreService {
   }
 
   @Transactional
-  public void updateScore(Long userId, int score, ActivityAt activityAt) {
+  public void upsertScore(Long userId, int score, ActivityAt activityAt) {
     LocalDate date = activityAt.toDate();
 
     toiletScoreRepository

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreUpsertUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletScoreUpsertUseCase.java
@@ -1,0 +1,24 @@
+package depromeet.lessonfour.server.report.app.service;
+
+import depromeet.lessonfour.server.common.annotation.UseCase;
+import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ToiletScoreUpsertUseCase {
+
+  private final ToiletReportService toiletReportService;
+  private final ToiletScoreService toiletScoreService;
+
+  public void upsertToiletScore(Long userId, ActivityAt activityAt) {
+
+    // 일간 배변 리포트 생성
+    DailyToiletReport dailyToiletReport =
+        toiletReportService.generateDailyReport(userId, activityAt);
+
+    // 배변 점수 업데이트
+    toiletScoreService.upsertScore(userId, (int) dailyToiletReport.getToiletScore(), activityAt);
+  }
+}


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 일간 리포트 생성시 배변 점수 업데이트 의존성 수정

## Changes ✨
* Application Service 대신 usecase에서 업데이트를 하도록 변경
* 배변 기록 생성 시 application service를 호출하여 점수를 업데이트하는 대신 별도의 usecase를 만들어 변경 의존성을 줄임

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 화장실 점수 업데이트 기능의 내부 구조를 개선하였습니다.
  * 서비스 간 의존성을 재정리하고 메서드 호출 흐름을 최적화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->