### PR TITLE
Update message when food data is missing

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/activity/FoodMapper.java
@@ -110,17 +110,27 @@ public class FoodMapper {
 
   private static String getMessage(List<FoodEvaluation> foodEvaluations) {
     final String DANGEROUS_MESSAGE = "맵고 자극적인 음식이 장을 자극했을 수 있어요";
-    final String SAFE_MESSAGE = "장에 좋은 음식 잘 선택하셨네요!";
+    final String SAFE_MESSAGE = "건강한 식단을 열심히 유지하고 계시네요!";
 
     FoodEvaluation todayEvaluation =
         foodEvaluations.stream()
             .filter(e -> e.getDayType() == DayType.TODAY)
             .findFirst()
             .orElse(null);
-    if (foodEvaluations.isEmpty()
-        || todayEvaluation == null
-        || todayEvaluation.getFoodsByMealTime().isEmpty()) {
-      return "음식 기록이 없어요. 장에 좋은 음식을 먹어볼까요?";
+    FoodEvaluation yesterdayEvaluation =
+        foodEvaluations.stream()
+            .filter(e -> e.getDayType() == DayType.YESTERDAY)
+            .findFirst()
+            .orElse(null);
+    boolean empty = true;
+    if (todayEvaluation != null && !todayEvaluation.getFoodsByMealTime().isEmpty()) {
+      empty = false;
+    }
+    if (yesterdayEvaluation != null && !yesterdayEvaluation.getFoodsByMealTime().isEmpty()) {
+      empty = false;
+    }
+    if (empty) {
+      return "기록한 식단이 없어요! 자세히 기록할수록 분석이 정확해져요!";
     }
     boolean eatDangerousFood = foodEvaluations.stream().anyMatch(FoodEvaluation::isDangerous);
 

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/StressMapperTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/StressMapperTest.java
@@ -24,10 +24,10 @@ class StressMapperTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.message()).isEqualTo("삐용삐용! 스트레스 만땅! 산책이나 명상을 해볼까요?");
+    assertThat(result.message()).isEqualTo("스트레스 Zero! 행복한 하루가 되셨군요?");
     assertThat(result.image())
         .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/very_bad.png");
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/very_good.png");
   }
 
   @Test
@@ -41,10 +41,10 @@ class StressMapperTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.message()).isEqualTo("스트레스에 잡아먹히지 않도록 조심해봐요!");
+    assertThat(result.message()).isEqualTo("긍정적인 당신! 그 마인드 오래도록 유지해봐요");
     assertThat(result.image())
         .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/bad.png");
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/good.png");
   }
 
   @Test
@@ -75,10 +75,10 @@ class StressMapperTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.message()).isEqualTo("긍정적인 당신! 그 마인드 오래도록 유지해봐요");
+    assertThat(result.message()).isEqualTo("스트레스에 잡아먹히지 않도록 조심해봐요!");
     assertThat(result.image())
         .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/good.png");
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/bad.png");
   }
 
   @Test
@@ -92,10 +92,10 @@ class StressMapperTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.message()).isEqualTo("스트레스 Zero! 행복한 하루가 되셨군요?");
+    assertThat(result.message()).isEqualTo("삐용삐용! 스트레스 만땅! 산책이나 명상을 해볼까요?");
     assertThat(result.image())
         .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/very_good.png");
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/stress/very_bad.png");
   }
 
   @Test


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
<!-- 작업 내용을 간단히 소개주세요 -->

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

- 어제 또는 오늘 음식 데이터가 있는 경우에도 기록이 없다고 나오는 버그를 해결합니다.

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 식단 피드백 메시지 문구 업데이트: 더 친근한 안전 메시지로 변경
  * 오늘과 어제 기록을 함께 확인해 식단 분석 정확도 개선
  * 식단 기록이 모두 없을 때 안내 메시지 추가로 사용성 향상

* **Tests**
  * 스트레스 피드백의 메시지·이미지 매칭이 반대 방향으로 조정되어 출력 검증 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->