### PR TITLE
Fix/홈 화면 캐릭터가 일간 리포트 캐릭터와 다른 오류 수정

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/recordquery/api/controller/HomeController.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/api/controller/HomeController.java
@@ -12,8 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import depromeet.lessonfour.server.common.api.code.SuccessCode;
 import depromeet.lessonfour.server.common.api.dto.SuccessResponse;
-import depromeet.lessonfour.server.recordquery.app.dto.HomeResponseDto;
-import depromeet.lessonfour.server.recordquery.app.service.GetDailyRecordUseCase;
+import depromeet.lessonfour.server.recordquery.api.dto.HomeOverviewResponse;
+import depromeet.lessonfour.server.recordquery.api.mapper.HomeMapper;
+import depromeet.lessonfour.server.recordquery.app.dto.DailyOverviewDto;
+import depromeet.lessonfour.server.recordquery.app.service.GetDailyOverviewUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -25,14 +27,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class HomeController {
 
-  private final GetDailyRecordUseCase getDailyRecordUseCase;
+  private final GetDailyOverviewUseCase getDailyOverviewUseCase;
+  private final HomeMapper homeMapper;
 
   @Operation(summary = "홈 데이터 조회", description = "특정 날짜의 홈 화면 정보를 조회합니다.")
   @GetMapping("/{date}")
-  public SuccessResponse<HomeResponseDto> getHome(
+  public SuccessResponse<HomeOverviewResponse> getHome(
       @AuthenticationPrincipal(expression = "id") Long userId,
       @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-    return SuccessResponse.of(
-        SuccessCode.SUCCESS_FETCH, getDailyRecordUseCase.getHomeRecord(userId, date));
+    DailyOverviewDto dailyOverview = getDailyOverviewUseCase.getDailyOverview(userId, date);
+
+    return SuccessResponse.of(SuccessCode.SUCCESS_FETCH, homeMapper.map(dailyOverview));
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/api/dto/HomeOverviewResponse.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/api/dto/HomeOverviewResponse.java
@@ -1,8 +1,8 @@
-package depromeet.lessonfour.server.recordquery.app.dto;
+package depromeet.lessonfour.server.recordquery.api.dto;
 
 import java.util.List;
 
-public record HomeResponseDto(
+public record HomeOverviewResponse(
     int toiletRecordCount,
     boolean hasActivityRecord,
     String heroImage,

--- a/src/main/java/depromeet/lessonfour/server/recordquery/api/mapper/HomeMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/api/mapper/HomeMapper.java
@@ -1,0 +1,54 @@
+package depromeet.lessonfour.server.recordquery.api.mapper;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import depromeet.lessonfour.server.recordquery.api.dto.HomeOverviewResponse;
+import depromeet.lessonfour.server.recordquery.app.dto.DailyOverviewDto;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
+
+@Component
+public class HomeMapper {
+
+  private static final Map<ToiletEvaluationLevel, ToiletHeroAssets> HOME_ASSETS =
+      Map.of(
+          ToiletEvaluationLevel.VERY_BAD,
+          new ToiletHeroAssets(
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_bad.png",
+              List.of("#A4141E", "#FF535F")),
+          ToiletEvaluationLevel.BAD,
+          new ToiletHeroAssets(
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/bad.png",
+              List.of("#DD5612", "#F6A85F")),
+          ToiletEvaluationLevel.AVERAGE,
+          new ToiletHeroAssets(
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png",
+              List.of("#2B42B4", "#8F58FF")),
+          ToiletEvaluationLevel.GOOD,
+          new ToiletHeroAssets(
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/good.png",
+              List.of("#134DB1", "#588DFF")),
+          ToiletEvaluationLevel.VERY_GOOD,
+          new ToiletHeroAssets(
+              "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_good.png",
+              List.of("#0C7C30", "#7DD357")));
+
+  record ToiletHeroAssets(String image, List<String> backgroundColors) {}
+
+  public HomeOverviewResponse map(DailyOverviewDto dto) {
+
+    ToiletEvaluationLevel toiletEvaluationLevel = dto.toiletEvaluationLevel();
+
+    // fallback 처리
+    if (toiletEvaluationLevel == null || toiletEvaluationLevel == ToiletEvaluationLevel.NONE) {
+      toiletEvaluationLevel = ToiletEvaluationLevel.AVERAGE;
+    }
+
+    ToiletHeroAssets asset = HOME_ASSETS.get(toiletEvaluationLevel);
+
+    return new HomeOverviewResponse(
+        dto.toiletRecordCount(), dto.hasActivityRecord(), asset.image, asset.backgroundColors);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ReportClient.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ReportClient.java
@@ -1,8 +1,11 @@
 package depromeet.lessonfour.server.recordquery.app.client;
 
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 
 public interface ReportClient {
 
   int getScoreByActivityAt(Long userId, ActivityAt activityAt);
+
+  DailyToiletReport getDailyToiletReportByActivityAt(Long userId, ActivityAt activityAt);
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ToiletRecordClient.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/client/ToiletRecordClient.java
@@ -11,8 +11,4 @@ public interface ToiletRecordClient {
       Long userId, ActivityAt startInclude, ActivityAt endInclude);
 
   int getToiletRecordCountByActivityAt(Long userId, ActivityAt activityAt);
-
-  HeroAssets getToiletHeroAssets(int score);
-
-  record HeroAssets(String image, List<String> backgroundColors) {}
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/dto/DailyOverviewDto.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/dto/DailyOverviewDto.java
@@ -1,0 +1,8 @@
+package depromeet.lessonfour.server.recordquery.app.dto;
+
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
+
+public record DailyOverviewDto(
+    ToiletEvaluationLevel toiletEvaluationLevel,
+    int toiletRecordCount,
+    boolean hasActivityRecord) {}

--- a/src/main/java/depromeet/lessonfour/server/recordquery/app/service/GetDailyOverviewUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/app/service/GetDailyOverviewUseCase.java
@@ -6,25 +6,27 @@ import depromeet.lessonfour.server.common.annotation.UseCase;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.recordquery.app.client.ActivityRecordClient;
 import depromeet.lessonfour.server.recordquery.app.client.ReportClient;
-import depromeet.lessonfour.server.recordquery.app.client.ToiletRecordClient;
-import depromeet.lessonfour.server.recordquery.app.dto.DailyRecordResponse;
+import depromeet.lessonfour.server.recordquery.app.dto.DailyOverviewDto;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
-public class GetDailyRecordUseCase {
+public class GetDailyOverviewUseCase {
 
-  private final ActivityRecordClient activityRecordClient;
-  private final ToiletRecordClient toiletRecordClient;
   private final ReportClient reportClient;
+  private final ActivityRecordClient activityRecordClient;
 
-  public DailyRecordResponse getDailyRecord(Long userId, LocalDate date) {
+  public DailyOverviewDto getDailyOverview(Long userId, LocalDate date) {
     ActivityAt activityAt = ActivityAt.of(date);
 
-    int score = reportClient.getScoreByActivityAt(userId, activityAt);
-    int toiletRecordCount = toiletRecordClient.getToiletRecordCountByActivityAt(userId, activityAt);
+    // 배변 리포트 조회
+    DailyToiletReport dailyReport =
+        reportClient.getDailyToiletReportByActivityAt(userId, activityAt);
+
+    // 생활 기록 존재 여부 조회
     boolean activityRecordExists = activityRecordClient.existsByActivityAt(userId, activityAt);
 
-    return new DailyRecordResponse(score, toiletRecordCount, activityRecordExists);
+    return new DailyOverviewDto(dailyReport.getLevel(), dailyReport.size(), activityRecordExists);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/infra/ReportClientImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/infra/ReportClientImpl.java
@@ -4,17 +4,25 @@ import org.springframework.stereotype.Component;
 
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.recordquery.app.client.ReportClient;
+import depromeet.lessonfour.server.report.app.service.ToiletReportService;
 import depromeet.lessonfour.server.report.app.service.ToiletScoreService;
+import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class ReportClientImpl implements ReportClient {
 
+  private final ToiletReportService toiletReportService;
   private final ToiletScoreService toiletScoreService;
 
   @Override
   public int getScoreByActivityAt(Long userId, ActivityAt activityAt) {
     return toiletScoreService.getScoreByActivityAt(userId, activityAt);
+  }
+
+  @Override
+  public DailyToiletReport getDailyToiletReportByActivityAt(Long userId, ActivityAt activityAt) {
+    return toiletReportService.generateDailyReport(userId, activityAt);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
+++ b/src/main/java/depromeet/lessonfour/server/recordquery/infra/ToiletRecordClientImpl.java
@@ -7,8 +7,6 @@ import org.springframework.stereotype.Component;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.common.domain.vo.DailyExistence;
 import depromeet.lessonfour.server.recordquery.app.client.ToiletRecordClient;
-import depromeet.lessonfour.server.report.api.mapper.toilet.ToiletReportMapper;
-import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
 import depromeet.lessonfour.server.toiletrecord.app.service.ToiletRecordQueryService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 public class ToiletRecordClientImpl implements ToiletRecordClient {
 
   private final ToiletRecordQueryService toiletRecordQueryService;
-  private final ToiletReportMapper toiletReportMapper;
 
   @Override
   public List<DailyExistence> getDailyExistencesBetween(
@@ -28,16 +25,5 @@ public class ToiletRecordClientImpl implements ToiletRecordClient {
   @Override
   public int getToiletRecordCountByActivityAt(Long userId, ActivityAt activityAt) {
     return toiletRecordQueryService.countByActivityAt(userId, activityAt);
-  }
-
-  @Override
-  public ToiletRecordClient.HeroAssets getToiletHeroAssets(int score) {
-    if (score == 0) {
-      var assets = toiletReportMapper.heroAssetsByLevel(ToiletEvaluationLevel.AVERAGE);
-      return new ToiletRecordClient.HeroAssets(assets.image(), assets.backgroundColors());
-    }
-    var level = ToiletEvaluationLevel.from(score);
-    var assets = toiletReportMapper.heroAssetsByLevel(level);
-    return new ToiletRecordClient.HeroAssets(assets.image(), assets.backgroundColors());
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -39,13 +39,6 @@ public class ToiletReportMapper {
     return DailyMapper.map(dailyToiletReport);
   }
 
-  public record ToiletHeroAssets(String image, List<String> backgroundColors) {}
-
-  public ToiletHeroAssets heroAssetsByLevel(ToiletEvaluationLevel level) {
-    var hero = DailyMapper.lookupHero(level); // 내부 맵 재사용
-    return new ToiletHeroAssets(hero.image(), hero.backgroundColors());
-  }
-
   /** 배변 모양 섹션 매핑 */
   public MonthlyShapeSection mapShape(MonthlyReport report) {
     final String titleMessage = "이번 달 자주 본 배변 모양이에요";
@@ -280,15 +273,6 @@ public class ToiletReportMapper {
             "대체로 좋은 상태예요. 식이섬유나 수분 섭취가 잘 이루어졌을 가능성이 높아요. 가벼운 운동이나 스트레칭으로 리듬을 이어가면 좋을 것 같아요.",
             ToiletEvaluationLevel.VERY_GOOD,
             "오늘은 장이 최상의 컨디션이에요. 규칙적이고 건강한 식습관과 충분한 수분 섭취가 잘 이루어지고 있네요. 지금처럼 꾸준히 유지해보세요.");
-
-    // 내부 맵을 안전하게 노출하는 조회 함수 (NONE/NULL 폴백 포함)
-    static HeroCharacter lookupHero(ToiletEvaluationLevel level) {
-      ToiletEvaluationLevel safeLevel =
-          (level == null || level == ToiletEvaluationLevel.NONE)
-              ? ToiletEvaluationLevel.AVERAGE
-              : level;
-      return characterMap.getOrDefault(safeLevel, characterMap.get(ToiletEvaluationLevel.AVERAGE));
-    }
 
     static DailyToiletReportDto map(DailyToiletReport dailyToiletReport) {
       if (dailyToiletReport.getLevel() == ToiletEvaluationLevel.NONE) {

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/DailyToiletReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/DailyToiletReport.java
@@ -34,4 +34,8 @@ public class DailyToiletReport {
 
     return new DailyToiletReport(averageScore, level, evaluations);
   }
+
+  public int size() {
+    return items.size();
+  }
 }

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -16,29 +16,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 
-import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
-import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
-import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
-import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
-import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
 import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
 import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
-import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.food.domain.entity.Food;
 import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
-import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
-import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
-import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
-import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.domain.repository.UserRepository;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -54,14 +44,12 @@ class HomeE2ETest {
   @Autowired UserRepository userRepository;
   @Autowired PasswordEncoder passwordEncoder;
   @Autowired FoodRepository foodRepository;
-  @Autowired JpaActivityRecordRepository activityRecordRepository;
-  @Autowired ToiletRecordRepository toiletRecordRepository;
-  @Autowired JdbcTemplate jdbcTemplate;
 
   private String validJwtToken;
-  private Long testUserId;
   private User testUser;
   private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+  private final DateTimeFormatter dateTimeFormatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
   @BeforeEach
   void setUp() {
@@ -69,7 +57,6 @@ class HomeE2ETest {
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
     testUser = createTestUser("home@test.com", "pw1234", "home-user");
-    testUserId = testUser.getId();
     validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
 
     // 테스트용 Food 한 개
@@ -84,32 +71,56 @@ class HomeE2ETest {
     return userRepository.save(u);
   }
 
-  private ActivityRecord createActivity(LocalDateTime dt) {
+  private void createActivity(LocalDateTime dt) {
     List<Food> foods = foodRepository.findAll();
-    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.get(0)));
-    return activityRecordRepository.save(
-        ActivityRecord.createWithMeals(
-            testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dt), items));
+    Long foodId = foods.getFirst().getId();
+
+    String createRequest =
+        String.format(
+            """
+        {
+          "foods": [{"id": %d, "mealTime": "BREAKFAST"}],
+          "water": 5,
+          "stress": "MEDIUM",
+          "occurredAt": "%s"
+        }
+        """,
+            foodId, dt.format(dateTimeFormatter));
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(createRequest)
+        .when()
+        .post("/api/v1/activity-records")
+        .then()
+        .statusCode(HttpStatus.CREATED.value());
   }
 
-  private ToiletRecord createToilet(LocalDateTime dt) {
-    var r =
-        ToiletRecord.register(
-            testUser,
-            true,
-            ToiletColor.DEFAULT,
-            ToiletShape.BANANA,
-            20,
-            5,
-            "note",
-            ActivityAt.from(dt));
-    toiletRecordRepository.save(r);
-    return r;
-  }
+  private void createToilet(LocalDateTime dt, String color, String shape, int pain, int duration) {
+    String createRequest =
+        String.format(
+            """
+        {
+          "occurredAt": "%s",
+          "isSuccessful": true,
+          "color": "%s",
+          "shape": "%s",
+          "pain": %d,
+          "duration": %d,
+          "note": "note"
+        }
+        """,
+            dt.format(dateTimeFormatter), color, shape, pain, duration);
 
-  private void insertToiletScore(Long userId, LocalDate date, int score) {
-    jdbcTemplate.update(
-        "INSERT INTO toilet_score (user_id, date, score) VALUES (?, ?, ?)", userId, date, score);
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(createRequest)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.OK.value());
   }
 
   @Test
@@ -117,10 +128,12 @@ class HomeE2ETest {
   void home_ok_good() {
     LocalDate date = LocalDate.of(2024, 10, 5);
     // score=75 → GOOD(60–79)
-    insertToiletScore(testUserId, date, 75);
-    // records
-    createToilet(LocalDateTime.of(2024, 10, 5, 8, 0));
-    createToilet(LocalDateTime.of(2024, 10, 5, 14, 0));
+    // 2개 기록의 평균: (85+65)/2 = 75
+    // 기록1: 50+50+0-15(CORN)+0+0 = 85
+    // 기록2: 50+50+0-15(CORN)+0-20(통증25) = 65
+    createToilet(LocalDateTime.of(2024, 10, 5, 8, 0), "DEFAULT", "CORN", 10, 5);
+    createToilet(LocalDateTime.of(2024, 10, 5, 14, 0), "DEFAULT", "CORN", 25, 5);
+
     // activity exists
     createActivity(LocalDateTime.of(2024, 10, 5, 10, 0));
 
@@ -141,10 +154,12 @@ class HomeE2ETest {
   }
 
   @Test
-  @DisplayName("[home] 점수 82(VERY_GOOD) + 기록없음 → hero=VERY_GOOD 이미지/컬러, 카운트0/활동false")
-  void home_ok_veryGood_noRecords() {
+  @DisplayName("[home] 점수 85(VERY_GOOD) + 화장실 1건 + 활동없음 → hero=VERY_GOOD 이미지/컬러")
+  void home_ok_veryGood() {
     LocalDate date = LocalDate.of(2024, 10, 6);
-    insertToiletScore(testUserId, date, 82);
+    // score=85 → VERY_GOOD(80–100)
+    // 1개 기록: 50+50+0-15(CORN)+0+0 = 85
+    createToilet(LocalDateTime.of(2024, 10, 6, 8, 0), "DEFAULT", "CORN", 10, 5);
 
     given()
         .header("Authorization", validJwtToken)
@@ -155,7 +170,7 @@ class HomeE2ETest {
         .statusCode(HttpStatus.OK.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(200))
-        .body("data.toiletRecordCount", equalTo(0))
+        .body("data.toiletRecordCount", equalTo(1))
         .body("data.hasActivityRecord", equalTo(false))
         .body("data.heroImage", containsString("toilet/very_good.png"))
         .body("data.heroBackgroundColors", hasItems("#0C7C30", "#7DD357"));
@@ -165,7 +180,9 @@ class HomeE2ETest {
   @DisplayName("[home] 점수 15(VERY_BAD) → hero=VERY_BAD 이미지/컬러")
   void home_ok_veryBad() {
     LocalDate date = LocalDate.of(2024, 10, 7);
-    insertToiletScore(testUserId, date, 15);
+    // score=15 → VERY_BAD(0–19)
+    // 1개 기록: 50+50-40(RED)-45(RABBIT)+0+0 = 15
+    createToilet(LocalDateTime.of(2024, 10, 7, 8, 0), "RED", "RABBIT", 10, 5);
 
     given()
         .header("Authorization", validJwtToken)
@@ -184,8 +201,9 @@ class HomeE2ETest {
   @DisplayName("[home] 경계값 매핑 확인: 60(GOOD), 40(AVERAGE), 20(BAD)")
   void home_ok_boundaries() {
     // 60 → GOOD
+    // 기록: 50+50-10(DARK_BROWN)-30(PORRIDGE)+0+0 = 60
     LocalDate d1 = LocalDate.of(2024, 10, 8);
-    insertToiletScore(testUserId, d1, 60);
+    createToilet(LocalDateTime.of(2024, 10, 8, 8, 0), "DARK_BROWN", "PORRIDGE", 10, 5);
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -197,8 +215,9 @@ class HomeE2ETest {
         .body("data.heroBackgroundColors", hasItems("#134DB1", "#588DFF"));
 
     // 40 → AVERAGE
+    // 기록: 50+50-10(DARK_BROWN)-30(PORRIDGE)-20(통증25)+0 = 40
     LocalDate d2 = LocalDate.of(2024, 10, 9);
-    insertToiletScore(testUserId, d2, 40);
+    createToilet(LocalDateTime.of(2024, 10, 9, 8, 0), "DARK_BROWN", "PORRIDGE", 25, 5);
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -210,8 +229,9 @@ class HomeE2ETest {
         .body("data.heroBackgroundColors", hasItems("#2B42B4", "#8F58FF"));
 
     // 20 → BAD
+    // 기록: 50+50-40(RED)-30(PORRIDGE)+0-10(시간15분) = 20
     LocalDate d3 = LocalDate.of(2024, 10, 10);
-    insertToiletScore(testUserId, d3, 20);
+    createToilet(LocalDateTime.of(2024, 10, 10, 8, 0), "RED", "PORRIDGE", 10, 15);
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -274,33 +294,61 @@ class HomeE2ETest {
   @DisplayName("[home] 다른 사용자 데이터는 카운트/활동/점수에 반영되지 않는다")
   void home_otherUser_notCounted() {
     User other = createTestUser("other@ex.com", "pw", "other");
+    String otherJwtToken =
+        "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(other));
     LocalDate date = LocalDate.of(2024, 10, 11);
 
-    // 다른 사용자 기록/점수
-    var foods = foodRepository.findAll();
-    var items = List.of(new MealFood(MealTime.BREAKFAST, foods.get(0)));
-    activityRecordRepository.save(
-        ActivityRecord.createWithMeals(
-            other.getId(),
-            5,
-            StressLevel.MEDIUM,
-            ActivityAt.from(LocalDateTime.of(2024, 10, 11, 9, 0)),
-            items));
-    toiletRecordRepository.save(
-        ToiletRecord.register(
-            other,
-            true,
-            ToiletColor.DEFAULT,
-            ToiletShape.BANANA,
-            20,
-            5,
-            "other",
-            ActivityAt.from(LocalDateTime.of(2024, 10, 11, 8, 0))));
-    jdbcTemplate.update(
-        "INSERT INTO toilet_score (user_id, date, score) VALUES (?, ?, ?)",
-        other.getId(),
-        date,
-        95);
+    // 다른 사용자 생활 기록 생성
+    List<Food> foods = foodRepository.findAll();
+    Long foodId = foods.getFirst().getId();
+    String activityRequest =
+        String.format(
+            """
+        {
+          "foods": [{"id": %d, "mealTime": "BREAKFAST"}],
+          "water": 5,
+          "stress": "MEDIUM",
+          "occurredAt": "%s"
+        }
+        """,
+            foodId, LocalDateTime.of(2024, 10, 11, 9, 0).format(dateTimeFormatter));
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", otherJwtToken)
+        .body(activityRequest)
+        .when()
+        .post("/api/v1/activity-records")
+        .then()
+        .statusCode(HttpStatus.CREATED.value());
+
+    // 다른 사용자 배변 기록 생성
+    String toiletRequest =
+        String.format(
+            """
+        {
+          "occurredAt": "%s",
+          "isSuccessful": true,
+          "color": "DEFAULT",
+          "shape": "BANANA",
+          "pain": 20,
+          "duration": 5,
+          "note": "other"
+        }
+        """,
+            LocalDateTime.of(2024, 10, 11, 8, 0).format(dateTimeFormatter));
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", otherJwtToken)
+        .body(toiletRequest)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    // 다른 사용자의 배변 기록은 자동으로 점수 계산됨
+    // 기록: 50+50+0+45(BANANA)+0+0 = 145 (capped at 100, VERY_GOOD)
 
     // 현재 사용자로 조회 → 0/false + hero는 기본(점수 없으면 AVERAGE로 매핑됨)
     given()

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/mapper/HomeMapperTest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/mapper/HomeMapperTest.java
@@ -1,0 +1,119 @@
+package depromeet.lessonfour.server.recordquery.api.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import depromeet.lessonfour.server.recordquery.api.dto.HomeOverviewResponse;
+import depromeet.lessonfour.server.recordquery.app.dto.DailyOverviewDto;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
+
+class HomeMapperTest {
+
+  HomeMapper mapper = new HomeMapper();
+
+  @Test
+  @DisplayName("VERY_GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenVeryGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.VERY_GOOD, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_good.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#0C7C30", "#7DD357");
+  }
+
+  @Test
+  @DisplayName("GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.GOOD, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/good.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#134DB1", "#588DFF");
+  }
+
+  @Test
+  @DisplayName("AVERAGE 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenAverageLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.AVERAGE, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+
+  @Test
+  @DisplayName("BAD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.BAD, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/bad.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#DD5612", "#F6A85F");
+  }
+
+  @Test
+  @DisplayName("VERY_BAD 레벨의 히어로 에셋을 올바르게 반환한다")
+  void givenVeryBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.VERY_BAD, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_bad.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#A4141E", "#FF535F");
+  }
+
+  @Test
+  @DisplayName("NONE 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
+  void givenNoneLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
+    // when
+    HomeOverviewResponse result =
+        mapper.map(new DailyOverviewDto(ToiletEvaluationLevel.NONE, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+
+  @Test
+  @DisplayName("null 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
+  void givenNullLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
+    // when
+    HomeOverviewResponse result = mapper.map(new DailyOverviewDto(null, 10, true));
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.heroImage())
+        .isEqualTo(
+            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
+    assertThat(result.heroBackgroundColors()).containsExactly("#2B42B4", "#8F58FF");
+  }
+}

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperDailyTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReportDto;
-import depromeet.lessonfour.server.report.api.mapper.toilet.ToiletReportMapper.ToiletHeroAssets;
 import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluation;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
@@ -219,104 +218,6 @@ class ToiletReportMapperDailyTest {
     assertThat(result.items()).hasSize(2);
     assertThat(result.items().get(0).note()).isEqualTo("morning");
     assertThat(result.items().get(1).note()).isEqualTo("afternoon");
-  }
-
-  @Test
-  @DisplayName("VERY_GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
-  void givenVeryGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.VERY_GOOD);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_good.png");
-    assertThat(result.backgroundColors()).containsExactly("#0C7C30", "#7DD357");
-  }
-
-  @Test
-  @DisplayName("GOOD 레벨의 히어로 에셋을 올바르게 반환한다")
-  void givenGoodLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.GOOD);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/good.png");
-    assertThat(result.backgroundColors()).containsExactly("#134DB1", "#588DFF");
-  }
-
-  @Test
-  @DisplayName("AVERAGE 레벨의 히어로 에셋을 올바르게 반환한다")
-  void givenAverageLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.AVERAGE);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
-    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
-  }
-
-  @Test
-  @DisplayName("BAD 레벨의 히어로 에셋을 올바르게 반환한다")
-  void givenBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.BAD);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/bad.png");
-    assertThat(result.backgroundColors()).containsExactly("#DD5612", "#F6A85F");
-  }
-
-  @Test
-  @DisplayName("VERY_BAD 레벨의 히어로 에셋을 올바르게 반환한다")
-  void givenVeryBadLevel_whenHeroAssetsByLevel_thenReturnCorrectAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.VERY_BAD);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/very_bad.png");
-    assertThat(result.backgroundColors()).containsExactly("#A4141E", "#FF535F");
-  }
-
-  @Test
-  @DisplayName("NONE 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
-  void givenNoneLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(ToiletEvaluationLevel.NONE);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
-    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
-  }
-
-  @Test
-  @DisplayName("null 레벨은 AVERAGE 레벨의 히어로 에셋으로 폴백한다")
-  void givenNullLevel_whenHeroAssetsByLevel_thenReturnAverageLevelAssets() {
-    // when
-    ToiletHeroAssets result = mapper.heroAssetsByLevel(null);
-
-    // then
-    assertThat(result).isNotNull();
-    assertThat(result.image())
-        .isEqualTo(
-            "https://kr.object.ncloudstorage.com/depromeet-dev-static-resources/toilet/normal.png");
-    assertThat(result.backgroundColors()).containsExactly("#2B42B4", "#8F58FF");
   }
 
   // Helper methods


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 홈 화면 캐릭터 선택시 하나의 배변 점수만 반영하는 오류 수정
* 홈 화면 캐릭터 선택시 일간 리포트 종합 점수를 이용하도록 수정
* 배변 기록 도메인에 존재하는 매핑 로직 제거 => recordquery에 매퍼 추가

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- 홈 페이지 데이터 조회 흐름을 개선했습니다.
- 영웅 이미지 자산 처리 로직을 재구성했습니다.

## Tests
- 홈 페이지 엔드-투-엔드 테스트를 업데이트했습니다.
- 홈 페이지 맵퍼 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->