### PR TITLE
Refactor/주간 리포트 도메인 로직 분리

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/common/domain/vo/WeekRange.java
+++ b/src/main/java/depromeet/lessonfour/server/common/domain/vo/WeekRange.java
@@ -1,0 +1,31 @@
+package depromeet.lessonfour.server.common.domain.vo;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+public record WeekRange(LocalDate start, LocalDate endExclusive) {
+
+  /** 이번 주의 WeekRange를 반환합니다. (월요일 시작, 다음주 월요일 종료) */
+  public static WeekRange of(LocalDate baseDate) {
+    LocalDate startOfWeek = baseDate.with(DayOfWeek.MONDAY);
+    LocalDate endOfWeek = startOfWeek.plusDays(7);
+
+    return new WeekRange(startOfWeek, endOfWeek);
+  }
+
+  /** 이전 주의 WeekRange를 반환합니다. */
+  public WeekRange previous() {
+    LocalDate startPrev = start.minusWeeks(1);
+    return new WeekRange(startPrev, startPrev.plusDays(7));
+  }
+
+  /** start를 ActivityAt으로 변환합니다. */
+  public ActivityAt startAsActivityAt() {
+    return ActivityAt.of(start);
+  }
+
+  /** endExclusive를 ActivityAt으로 변환합니다. */
+  public ActivityAt endAsActivityAt() {
+    return ActivityAt.of(endExclusive);
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/WeeklyReportMapper.java
@@ -38,7 +38,7 @@ public class WeeklyReportMapper {
     // 배변 점수 매핑
     DefecationScore defecationScore = mapDefecationScore(weeklyReport);
 
-    UserAverage userAverage = mapUserAverage(weeklyReport.thisWeekAverageScore());
+    UserAverage userAverage = mapUserAverage(weeklyReport.getThisWeekAverageScore());
 
     // 생활 기록 매핑
     WeeklyFoodSection foodSection =
@@ -64,9 +64,9 @@ public class WeeklyReportMapper {
 
   private static DefecationScore mapDefecationScore(WeeklyReport weeklyReport) {
     return new DefecationScore(
-        weeklyReport.lastWeekAverageScore(),
-        weeklyReport.thisWeekAverageScore(),
-        weeklyReport.dailyScores().stream().map(Double::valueOf).toList());
+        weeklyReport.getLastWeekAverageScore(),
+        weeklyReport.getThisWeekAverageScore(),
+        weeklyReport.getScoresThisWeek().stream().toList());
   }
 
   private static UserAverage mapUserAverage(double thisWeekAverageScore) {

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ActivityReportService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ActivityReportService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.common.domain.vo.WeekRange;
 import depromeet.lessonfour.server.report.app.client.ActivityRecordClient;
 import depromeet.lessonfour.server.report.domain.vo.activity.DailyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.activity.MonthlyActivityReport;
@@ -40,13 +41,13 @@ public class ActivityReportService {
   }
 
   /** 주간 생활 기록 리포트 생성 */
-  public WeeklyActivityReport generateWeeklyReport(
-      Long userId, ActivityAt startAt, ActivityAt endAt) {
+  public WeeklyActivityReport generateWeeklyReport(Long userId, WeekRange week) {
 
     List<ActivityRecord> records =
-        activityRecordClient.getActivityRecordsBetween(userId, startAt, endAt);
+        activityRecordClient.getActivityRecordsBetween(
+            userId, week.startAsActivityAt(), week.endAsActivityAt());
 
-    return WeeklyActivityReport.evaluateWeekly(records, startAt);
+    return WeeklyActivityReport.evaluateWeekly(records, week.startAsActivityAt());
   }
 
   /** 월간 생활 기록 리포트 생성 */

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/ToiletReportService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.common.domain.vo.WeekRange;
 import depromeet.lessonfour.server.report.app.client.ToiletRecordClient;
 import depromeet.lessonfour.server.report.domain.vo.toilet.DailyToiletReport;
 import depromeet.lessonfour.server.report.domain.vo.toilet.MonthlyToiletReport;
@@ -29,11 +30,11 @@ public class ToiletReportService {
   }
 
   /** 주간 배변 리포트 생성 */
-  public WeeklyToiletReport generateWeeklyReport(
-      Long userId, ActivityAt start, ActivityAt endExclusive) {
+  public WeeklyToiletReport generateWeeklyReport(Long userId, WeekRange week) {
 
     List<ToiletRecord> records =
-        toiletRecordClient.getToiletRecordsByActivityAtBetween(userId, start, endExclusive);
+        toiletRecordClient.getToiletRecordsByActivityAtBetween(
+            userId, week.startAsActivityAt(), week.endAsActivityAt());
 
     return WeeklyToiletReport.summarize(records);
   }

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
@@ -1,7 +1,5 @@
 package depromeet.lessonfour.server.report.app.service;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -10,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import depromeet.lessonfour.server.common.annotation.UseCase;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.common.domain.vo.WeekRange;
 import depromeet.lessonfour.server.report.domain.service.SuggestionService;
 import depromeet.lessonfour.server.report.domain.vo.WeeklyReport;
 import depromeet.lessonfour.server.report.domain.vo.activity.WeeklyActivityReport;
@@ -28,31 +27,19 @@ public class WeeklyReportUseCase {
   private final SuggestionService suggestionService;
 
   public WeeklyReport generateWeeklyReport(Long userId, LocalDateTime baseDateTime) {
-    LocalDate baseDate = baseDateTime.toLocalDate();
 
-    // 이번 주: 월요일 ~ 다음 주 월요일 직전까지 [start, end)
-    LocalDate thisWeekStartDate = baseDate.with(DayOfWeek.MONDAY);
-    LocalDate thisWeekEndExclusiveDate = thisWeekStartDate.plusDays(7);
-
-    // 지난 주: 이번 주 시작 -7일 ~ 이번 주 시작 [start, end)
-    LocalDate lastWeekStartDate = thisWeekStartDate.minusWeeks(1);
-
-    ActivityAt thisWeekStart = ActivityAt.of(thisWeekStartDate);
-    ActivityAt thisWeekEndExclusive = ActivityAt.of(thisWeekEndExclusiveDate);
-
-    ActivityAt lastWeekStart = ActivityAt.of(lastWeekStartDate);
-    ActivityAt lastWeekEndExclusive = ActivityAt.of(thisWeekStartDate);
+    WeekRange thisWeek = WeekRange.of(baseDateTime.toLocalDate());
+    WeekRange lastWeek = thisWeek.previous();
 
     // 주간 활동 리포트
     WeeklyActivityReport thisWeekActivity =
-        activityReportService.generateWeeklyReport(userId, thisWeekStart, thisWeekEndExclusive);
+        activityReportService.generateWeeklyReport(userId, thisWeek);
 
     WeeklyActivityReport lastWeekActivity =
-        activityReportService.generateWeeklyReport(userId, lastWeekStart, lastWeekEndExclusive);
+        activityReportService.generateWeeklyReport(userId, lastWeek);
 
     // 주간 배변 리포트 (DailyToiletReport 7개 기반 WeeklyToiletReport)
-    WeeklyToiletReport thisWeekToilet =
-        toiletReportService.generateWeeklyReport(userId, thisWeekStart, thisWeekEndExclusive);
+    WeeklyToiletReport thisWeekToilet = toiletReportService.generateWeeklyReport(userId, thisWeek);
 
     // 이번 주 점수 (월~일)
     List<Integer> thisWeekDailyScores =
@@ -60,7 +47,7 @@ public class WeeklyReportUseCase {
             .mapToObj(
                 i ->
                     toiletScoreService.getScoreByActivityAt(
-                        userId, ActivityAt.of(thisWeekStartDate.plusDays(i))))
+                        userId, ActivityAt.of(thisWeek.start().plusDays(i))))
             .toList();
 
     double thisWeekAverageScore =
@@ -72,7 +59,7 @@ public class WeeklyReportUseCase {
             .mapToObj(
                 i ->
                     toiletScoreService.getScoreByActivityAt(
-                        userId, ActivityAt.of(lastWeekStartDate.plusDays(i))))
+                        userId, ActivityAt.of(lastWeek.start().plusDays(i))))
             .toList();
 
     double lastWeekAverageScore =

--- a/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
+++ b/src/main/java/depromeet/lessonfour/server/report/app/service/WeeklyReportUseCase.java
@@ -2,12 +2,10 @@ package depromeet.lessonfour.server.report.app.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import org.springframework.transaction.annotation.Transactional;
 
 import depromeet.lessonfour.server.common.annotation.UseCase;
-import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.common.domain.vo.WeekRange;
 import depromeet.lessonfour.server.report.domain.service.SuggestionService;
 import depromeet.lessonfour.server.report.domain.vo.WeeklyReport;
@@ -23,7 +21,6 @@ public class WeeklyReportUseCase {
 
   private final ToiletReportService toiletReportService;
   private final ActivityReportService activityReportService;
-  private final ToiletScoreService toiletScoreService;
   private final SuggestionService suggestionService;
 
   public WeeklyReport generateWeeklyReport(Long userId, LocalDateTime baseDateTime) {
@@ -31,49 +28,20 @@ public class WeeklyReportUseCase {
     WeekRange thisWeek = WeekRange.of(baseDateTime.toLocalDate());
     WeekRange lastWeek = thisWeek.previous();
 
-    // 주간 활동 리포트
+    // 주간 생활기록 리포트
     WeeklyActivityReport thisWeekActivity =
         activityReportService.generateWeeklyReport(userId, thisWeek);
-
     WeeklyActivityReport lastWeekActivity =
         activityReportService.generateWeeklyReport(userId, lastWeek);
 
-    // 주간 배변 리포트 (DailyToiletReport 7개 기반 WeeklyToiletReport)
+    // 주간 배변기록 리포트
     WeeklyToiletReport thisWeekToilet = toiletReportService.generateWeeklyReport(userId, thisWeek);
-
-    // 이번 주 점수 (월~일)
-    List<Integer> thisWeekDailyScores =
-        IntStream.range(0, 7)
-            .mapToObj(
-                i ->
-                    toiletScoreService.getScoreByActivityAt(
-                        userId, ActivityAt.of(thisWeek.start().plusDays(i))))
-            .toList();
-
-    double thisWeekAverageScore =
-        thisWeekDailyScores.stream().mapToInt(Integer::intValue).average().orElse(0.0);
-
-    // 지난 주 평균 점수
-    List<Integer> lastWeekDailyScores =
-        IntStream.range(0, 7)
-            .mapToObj(
-                i ->
-                    toiletScoreService.getScoreByActivityAt(
-                        userId, ActivityAt.of(lastWeek.start().plusDays(i))))
-            .toList();
-
-    double lastWeekAverageScore =
-        lastWeekDailyScores.stream().mapToInt(Integer::intValue).average().orElse(0.0);
+    WeeklyToiletReport lastWeekToilet = toiletReportService.generateWeeklyReport(userId, lastWeek);
 
     // 주간 기준 습관 추천 (대표 하루 X, 주간 평균/횟수 기반)
     List<SuggestionType> suggestions = suggestionService.suggest(thisWeekActivity, thisWeekToilet);
 
     return new WeeklyReport(
-        lastWeekAverageScore,
-        thisWeekAverageScore,
-        thisWeekDailyScores,
-        lastWeekActivity,
-        thisWeekActivity,
-        suggestions);
+        lastWeekToilet, thisWeekToilet, lastWeekActivity, thisWeekActivity, suggestions);
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/WeeklyReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/WeeklyReport.java
@@ -4,12 +4,28 @@ import java.util.List;
 
 import depromeet.lessonfour.server.report.domain.vo.activity.WeeklyActivityReport;
 import depromeet.lessonfour.server.report.domain.vo.suggestion.SuggestionType;
+import depromeet.lessonfour.server.report.domain.vo.toilet.WeeklyToiletReport;
 
 public record WeeklyReport(
-    double lastWeekAverageScore,
-    double thisWeekAverageScore,
-    List<Integer> dailyScores, // 이번 주 월~일 점수
-    WeeklyActivityReport lastWeekActivity, // 지난 주 액티비티 요약
-    WeeklyActivityReport thisWeekActivity, // 이번 주 액티비티 요약
+    WeeklyToiletReport lastWeekToilet,
+    WeeklyToiletReport thisWeekToilet,
+    WeeklyActivityReport lastWeekActivity,
+    WeeklyActivityReport thisWeekActivity,
     List<SuggestionType> suggestions // 주간 습관 제안
-    ) {}
+    ) {
+
+  /** 이번주 평균 점수 */
+  public double getThisWeekAverageScore() {
+    return thisWeekToilet.getAverageScore();
+  }
+
+  /** 지난주 평균 점수 */
+  public double getLastWeekAverageScore() {
+    return lastWeekToilet.getAverageScore();
+  }
+
+  /** 이번주 점수 리스트 */
+  public List<Double> getScoresThisWeek() {
+    return thisWeekToilet.getScores();
+  }
+}

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/WeeklyToiletReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/WeeklyToiletReport.java
@@ -53,4 +53,11 @@ public class WeeklyToiletReport {
   public ToiletEvaluationLevel getLevel() {
     return ToiletEvaluationLevel.from(getAverageScore());
   }
+
+  /** 일별 배변 점수 리스트 */
+  public List<Double> getScores() {
+    return dailyReports.stream()
+        .map(DailyToiletReport::getToiletScore)
+        .collect(Collectors.toList());
+  }
 }

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetWeeklyReportE2ETest.java
@@ -1,8 +1,7 @@
 package depromeet.lessonfour.server.report.api;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -21,23 +20,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
 
-import depromeet.lessonfour.server.activityrecord.domain.entity.ActivityRecord;
-import depromeet.lessonfour.server.activityrecord.domain.vo.MealFood;
-import depromeet.lessonfour.server.activityrecord.domain.vo.MealTime;
-import depromeet.lessonfour.server.activityrecord.domain.vo.StressLevel;
-import depromeet.lessonfour.server.activityrecord.infra.repository.JpaActivityRecordRepository;
 import depromeet.lessonfour.server.auth.domain.vo.AccountContext;
 import depromeet.lessonfour.server.auth.infra.security.jwt.JwtTokenGenerator;
-import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
 import depromeet.lessonfour.server.food.domain.entity.Food;
 import depromeet.lessonfour.server.food.infra.repository.FoodRepository;
-import depromeet.lessonfour.server.toiletrecord.domain.entity.ToiletRecord;
-import depromeet.lessonfour.server.toiletrecord.domain.repository.ToiletRecordRepository;
-import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
-import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 import depromeet.lessonfour.server.user.domain.entity.User;
 import depromeet.lessonfour.server.user.domain.repository.UserRepository;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -53,13 +43,11 @@ class GetWeeklyReportE2ETest {
   @Autowired private UserRepository userRepository;
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private FoodRepository foodRepository;
-  @Autowired private JpaActivityRecordRepository activityRecordRepository;
-  @Autowired private ToiletRecordRepository toiletRecordRepository;
 
   private String validJwtToken;
-  private Long testUserId;
   private User testUser;
-  private final DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+  private final DateTimeFormatter dateTimeFormatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
   @BeforeEach
   void setUp() {
@@ -67,11 +55,12 @@ class GetWeeklyReportE2ETest {
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
     testUser = createTestUser("weekly-report@example.com", "password123", "weekly-user");
-    testUserId = testUser.getId();
     validJwtToken = "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(testUser));
 
     // 최소 1개 식품 확보
-    foodRepository.save(Food.builder().name("사과").score(4.5).build());
+    if (foodRepository.count() == 0) {
+      foodRepository.save(Food.builder().name("사과").score(4.5).build());
+    }
   }
 
   private User createTestUser(String email, String password, String nickname) {
@@ -79,362 +68,209 @@ class GetWeeklyReportE2ETest {
     return userRepository.save(user);
   }
 
-  private ActivityRecord createActivity(LocalDateTime dateTime) {
+  private void createToilet(LocalDateTime dt, String color, String shape, int pain, int duration) {
+    String createRequest =
+        String.format(
+            """
+        {
+          "occurredAt": "%s",
+          "isSuccessful": true,
+          "color": "%s",
+          "shape": "%s",
+          "pain": %d,
+          "duration": %d,
+          "note": "test note"
+        }
+        """,
+            dt.format(dateTimeFormatter), color, shape, pain, duration);
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(createRequest)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.OK.value());
+  }
+
+  private void createActivity(LocalDateTime dt) {
     List<Food> foods = foodRepository.findAll();
-    List<MealFood> meals = List.of(new MealFood(MealTime.BREAKFAST, foods.getFirst()));
-    return activityRecordRepository.save(
-        ActivityRecord.createWithMeals(
-            testUserId, 5, StressLevel.MEDIUM, ActivityAt.from(dateTime), meals));
+    Long foodId = foods.getFirst().getId();
+
+    String createRequest =
+        String.format(
+            """
+        {
+          "foods": [{"id": %d, "mealTime": "BREAKFAST"}],
+          "water": 5,
+          "stress": "MEDIUM",
+          "occurredAt": "%s"
+        }
+        """,
+            foodId, dt.format(dateTimeFormatter));
+
+    given()
+        .contentType(ContentType.JSON)
+        .header("Authorization", validJwtToken)
+        .body(createRequest)
+        .when()
+        .post("/api/v1/activity-records")
+        .then()
+        .statusCode(HttpStatus.CREATED.value());
   }
 
-  private ToiletRecord createToilet(
-      LocalDateTime dateTime,
-      Boolean isSuccessful,
-      ToiletColor color,
-      ToiletShape shape,
-      Integer pain,
-      Integer duration,
-      String note) {
-    ToiletRecord rec =
-        ToiletRecord.register(
-            testUser,
-            isSuccessful != null ? isSuccessful : true,
-            color,
-            shape,
-            pain != null ? pain : 10,
-            duration != null ? duration : 5,
-            note,
-            ActivityAt.from(dateTime));
-    toiletRecordRepository.save(rec);
-    return rec;
-  }
-
-  private String weeklyUrl(LocalDateTime dateTime) {
-    return "/api/v1/reports/weekly?dateTime=" + dateTime.format(dtf);
-  }
-
-  // 1) 7일 모두 activity + toilet 존재
   @Test
-  @DisplayName("[E2E][weekly] 7일 모두 activity + toilet 존재 → 정상 리포트 반환")
-  void givenFullWeekActivityAndToilet_whenGetWeeklyReport_thenOk() {
-    // 주간 기준: 2024-01-15(월) ~ 2024-01-21(일)
-    LocalDateTime monday = LocalDateTime.of(2024, 1, 15, 10, 0);
+  @DisplayName("[weekly] 배변 기록 2건 + 생활 기록 2건 → 정상 생성")
+  void weeklyReport_success_with_2_toilets_and_2_activities() {
+    // Given: 같은 주 내 서로 다른 날짜에 배변 기록 2건 + 생활 기록 2건
+    // 2024-10-07 (월요일)부터 2024-10-13 (일요일)까지가 한 주
+    LocalDateTime day1 = LocalDateTime.of(2024, 10, 7, 10, 0); // 월요일
+    LocalDateTime day2 = LocalDateTime.of(2024, 10, 8, 14, 30); // 화요일 (다른 시간)
 
-    // 월~일 모두 activity + toilet 생성
-    for (int i = 0; i < 7; i++) {
-      LocalDateTime day = monday.plusDays(i);
-      createActivity(day);
-      createToilet(day.withHour(8), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "메모");
-    }
+    // 배변 기록 2건 (서로 다른 날짜)
+    createToilet(day1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(day2, "DEFAULT", "CORN", 15, 7);
 
+    // 생활 기록 2건 (서로 다른 날짜)
+    createActivity(day1);
+    createActivity(day2);
+
+    // 이전 주(2024-09-30 ~ 2024-10-06)에도 배변 기록 2건 필요
+    LocalDateTime lastWeekDay1 = LocalDateTime.of(2024, 9, 30, 10, 0); // 월요일
+    LocalDateTime lastWeekDay2 = LocalDateTime.of(2024, 10, 1, 10, 0); // 화요일
+    createToilet(lastWeekDay1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(lastWeekDay2, "DEFAULT", "BANANA", 10, 5);
+
+    // When & Then: 2024-10-07이 속한 주의 리포트 조회
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam("dateTime", day1.format(dateTimeFormatter))
         .when()
-        .get(weeklyUrl(monday.plusDays(3))) // 주 중 아무 날짜
+        .get("/api/v1/reports/weekly")
         .then()
         .statusCode(HttpStatus.OK.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(200))
-        .body("data.updatedAt", notNullValue())
+        .body("data", notNullValue())
         .body("data.defecationScore", notNullValue())
-        .body("data.defecationScore.dailyScore.size()", equalTo(7))
-        .body("data.userAverage", notNullValue())
-        .body("data.food", notNullValue())
-        .body("data.water", notNullValue())
-        .body("data.stress", notNullValue())
-        .body("data.suggestion", notNullValue());
+        .body("data.defecationScore.thisWeek", notNullValue())
+        .body("data.defecationScore.lastWeek", notNullValue());
   }
 
-  // 2) 일부 activity 없음 (toilet은 7일 모두 존재)
   @Test
-  @DisplayName("[E2E][weekly] 일부 activity 없음 → NPE 없이 정상 리포트 반환")
-  void givenPartialActivityMissing_whenGetWeeklyReport_thenOk() {
-    LocalDateTime monday = LocalDateTime.of(2024, 1, 22, 10, 0);
+  @DisplayName("[weekly] 배변 기록 2건 + 생활 기록 0건 → 정상 생성")
+  void weeklyReport_success_with_2_toilets_and_0_activities() {
+    // Given: 같은 주 내 서로 다른 날짜에 배변 기록만 2건
+    LocalDateTime baseDateTime = LocalDateTime.of(2024, 10, 7, 10, 0); // 월요일
+    LocalDateTime day2 = LocalDateTime.of(2024, 10, 8, 10, 0); // 화요일
 
-    // 월~일: toilet은 모두 생성
-    for (int i = 0; i < 7; i++) {
-      LocalDateTime day = monday.plusDays(i);
-      createToilet(day.withHour(9), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
-    }
+    createToilet(baseDateTime, "DEFAULT", "BANANA", 10, 5);
+    createToilet(day2, "DEFAULT", "BANANA", 10, 5);
 
-    // activity는 월/수/금만 생성
-    createActivity(monday.plusDays(0)); // 월
-    createActivity(monday.plusDays(2)); // 수
-    createActivity(monday.plusDays(4)); // 금
+    // 이전 주에도 배변 기록 2건 필요
+    LocalDateTime lastWeekDay1 = LocalDateTime.of(2024, 9, 30, 10, 0);
+    LocalDateTime lastWeekDay2 = LocalDateTime.of(2024, 10, 1, 10, 0);
+    createToilet(lastWeekDay1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(lastWeekDay2, "DEFAULT", "BANANA", 10, 5);
 
+    // When & Then
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam("dateTime", baseDateTime.format(dateTimeFormatter))
         .when()
-        .get(weeklyUrl(monday.plusDays(3)))
+        .get("/api/v1/reports/weekly")
         .then()
         .statusCode(HttpStatus.OK.value())
         .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(200))
-        .body("data.updatedAt", notNullValue())
+        .body("data", notNullValue())
         .body("data.defecationScore", notNullValue())
-        .body("data.defecationScore.dailyScore.size()", equalTo(7))
-        .body("data.userAverage", notNullValue())
-        .body("data.food", notNullValue())
-        .body("data.water", notNullValue())
-        .body("data.stress", notNullValue())
-        .body("data.suggestion", notNullValue());
+        .body("data.defecationScore.thisWeek", notNullValue())
+        .body("data.defecationScore.lastWeek", notNullValue());
   }
 
-  // 3) 일부 toilet 없음 (activity는 7일 모두 존재)
   @Test
-  @DisplayName("[E2E][weekly] 일부 toilet 없음 → NPE 없이 정상 리포트 반환")
-  void givenPartialToiletMissing_whenGetWeeklyReport_thenOk() {
-    LocalDateTime monday = LocalDateTime.of(2024, 1, 29, 10, 0);
+  @DisplayName("[weekly] 배변 기록 1건 + 생활 기록 2건 → 실패 (배변 기록 부족)")
+  void weeklyReport_fail_with_1_toilet_and_2_activities() {
+    // Given: 배변 기록 1건만 존재, 생활 기록은 2건
+    LocalDateTime baseDateTime = LocalDateTime.of(2024, 10, 7, 10, 0); // 월요일
+    LocalDateTime day2 = LocalDateTime.of(2024, 10, 8, 10, 0); // 화요일
 
-    // 월~일: activity 모두 생성
-    for (int i = 0; i < 7; i++) {
-      createActivity(monday.plusDays(i));
-    }
+    // 현재 주 배변 기록 1건만 (부족)
+    createToilet(baseDateTime, "DEFAULT", "BANANA", 10, 5);
 
-    // toilet은 화/목/토만 생성
-    createToilet(
-        monday.plusDays(1).withHour(8),
-        true,
-        ToiletColor.DEFAULT,
-        ToiletShape.BANANA,
-        10,
-        5,
-        null); // 화
-    createToilet(
-        monday.plusDays(3).withHour(8),
-        true,
-        ToiletColor.DEFAULT,
-        ToiletShape.CORN,
-        20,
-        8,
-        null); // 목
-    createToilet(
-        monday.plusDays(5).withHour(8),
-        true,
-        ToiletColor.DARK_BROWN,
-        ToiletShape.CREAM,
-        5,
-        3,
-        null); // 토
+    createActivity(baseDateTime);
+    createActivity(day2);
 
+    // 이전 주에는 배변 기록 2건 필요 (이전 주는 정상이어야 현재 주만 실패 확인)
+    LocalDateTime lastWeekDay1 = LocalDateTime.of(2024, 9, 30, 10, 0);
+    LocalDateTime lastWeekDay2 = LocalDateTime.of(2024, 10, 1, 10, 0);
+    createToilet(lastWeekDay1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(lastWeekDay2, "DEFAULT", "BANANA", 10, 5);
+
+    // When & Then: 배변 기록이 2건 미만이므로 에러
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam("dateTime", baseDateTime.format(dateTimeFormatter))
         .when()
-        .get(weeklyUrl(monday.plusDays(4)))
-        .then()
-        .statusCode(HttpStatus.OK.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(200))
-        .body("data.updatedAt", notNullValue())
-        .body("data.defecationScore", notNullValue())
-        .body("data.defecationScore.dailyScore.size()", equalTo(7))
-        .body("data.userAverage", notNullValue())
-        .body("data.food", notNullValue())
-        .body("data.water", notNullValue())
-        .body("data.stress", notNullValue())
-        .body("data.suggestion", notNullValue());
-  }
-
-  // 4) 일부 날짜는 activity + toilet 둘 다 없음 (중간에 구멍)
-  @Test
-  @DisplayName("[E2E][weekly] 일부 날짜에 activity/toilet 둘 다 없음 → 정상 리포트 반환")
-  void givenSomeDaysNoActivityAndToilet_whenGetWeeklyReport_thenOk() {
-    LocalDateTime monday = LocalDateTime.of(2024, 2, 5, 10, 0);
-
-    // 월/화: activity + toilet 있음
-    for (int i = 0; i < 2; i++) {
-      LocalDateTime day = monday.plusDays(i);
-      createActivity(day);
-      createToilet(day.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, null);
-    }
-
-    // 수/목: 아무 기록 없음
-
-    // 금: activity만 있음
-    createActivity(monday.plusDays(4));
-
-    // 토: toilet만 있음
-    createToilet(
-        monday.plusDays(5).withHour(9), true, ToiletColor.GOLD, ToiletShape.CORN, 15, 6, null);
-
-    // 일: 아무 기록 없음
-
-    given()
-        .header("Authorization", validJwtToken)
-        .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-        .get(weeklyUrl(monday.plusDays(3)))
-        .then()
-        .statusCode(HttpStatus.OK.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(200))
-        .body("data.updatedAt", notNullValue())
-        .body("data.defecationScore", notNullValue())
-        .body("data.defecationScore.dailyScore.size()", equalTo(7))
-        .body("data.userAverage", notNullValue())
-        .body("data.food", notNullValue())
-        .body("data.water", notNullValue())
-        .body("data.stress", notNullValue())
-        .body("data.suggestion", notNullValue());
-  }
-
-  // 5) 해당 주간에 activity, toilet 모두 없음
-  @Test
-  @DisplayName("[E2E][weekly] 해당 주간에 어떤 기록도 없음 → 리포트 생성 불가")
-  void givenNoRecords_whenGetWeeklyReport_thenFail() {
-    LocalDateTime monday = LocalDateTime.of(2024, 2, 12, 10, 0);
-
-    // 아무 기록도 생성하지 않음
-
-    given()
-        .header("Authorization", validJwtToken)
-        .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-        .get(weeklyUrl(monday.plusDays(2)))
+        .get("/api/v1/reports/weekly")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(400));
   }
 
   @Test
-  @DisplayName("[E2E][weekly] 생활 기록 7일 + 배변 기록 0일 → 데이터 부족으로 리포트 생성 불가")
-  void givenFullWeekActivityButNoToilet_whenGetWeeklyReport_thenFail() {
-    LocalDateTime monday = LocalDateTime.of(2024, 2, 12, 10, 0);
+  @DisplayName("[weekly] 배변 기록 1건 + 생활 기록 0건 → 실패 (배변 기록 부족)")
+  void weeklyReport_fail_with_1_toilet_and_0_activities() {
+    // Given: 배변 기록 1건만 존재
+    LocalDateTime baseDateTime = LocalDateTime.of(2024, 10, 7, 10, 0); // 월요일
 
-    // 월~일 모두 생활 기록만 생성
-    for (int i = 0; i < 7; i++) {
-      createActivity(monday.plusDays(i));
-    }
+    // 현재 주 배변 기록 1건만 (부족)
+    createToilet(baseDateTime, "DEFAULT", "BANANA", 10, 5);
 
-    // 배변 기록은 없음
+    // 이전 주에는 배변 기록 2건 필요
+    LocalDateTime lastWeekDay1 = LocalDateTime.of(2024, 9, 30, 10, 0);
+    LocalDateTime lastWeekDay2 = LocalDateTime.of(2024, 10, 1, 10, 0);
+    createToilet(lastWeekDay1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(lastWeekDay2, "DEFAULT", "BANANA", 10, 5);
 
+    // When & Then: 배변 기록이 2건 미만이므로 에러
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam("dateTime", baseDateTime.format(dateTimeFormatter))
         .when()
-        .get(weeklyUrl(monday.plusDays(2)))
+        .get("/api/v1/reports/weekly")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(400));
   }
 
-  // 6) 배변 기록이 하루만 있는 경우 → 실패
   @Test
-  @DisplayName("[E2E][weekly] 배변 기록 1일만 존재 → 데이터 부족으로 리포트 생성 불가")
-  void givenOnlyOneDayToiletRecord_whenGetWeeklyReport_thenFail() {
-    LocalDateTime monday = LocalDateTime.of(2024, 2, 19, 10, 0);
+  @DisplayName("[weekly] 배변 기록 0건 + 생활 기록 0건 → 실패 (데이터 없음)")
+  void weeklyReport_fail_with_0_toilets_and_0_activities() {
+    // Given: 현재 주 데이터 없음, 이전 주에는 데이터 있음
+    LocalDateTime baseDateTime = LocalDateTime.of(2024, 10, 7, 10, 0); // 월요일
 
-    // 월요일에만 배변 기록 생성
-    createToilet(
-        monday.withHour(8), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "1일만 기록");
+    // 이전 주에는 배변 기록 2건 필요
+    LocalDateTime lastWeekDay1 = LocalDateTime.of(2024, 9, 30, 10, 0);
+    LocalDateTime lastWeekDay2 = LocalDateTime.of(2024, 10, 1, 10, 0);
+    createToilet(lastWeekDay1, "DEFAULT", "BANANA", 10, 5);
+    createToilet(lastWeekDay2, "DEFAULT", "BANANA", 10, 5);
 
+    // When & Then: 배변 기록이 없으므로 에러
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)
+        .queryParam("dateTime", baseDateTime.format(dateTimeFormatter))
         .when()
-        .get(weeklyUrl(monday.plusDays(3)))
+        .get("/api/v1/reports/weekly")
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
         .body("status", equalTo(400));
-  }
-
-  // 7) 배변 기록이 2일 있는 경우 → 성공
-  @Test
-  @DisplayName("[E2E][weekly] 배변 기록 2일 존재 → 정상 리포트 반환")
-  void givenTwoDaysToiletRecords_whenGetWeeklyReport_thenOk() {
-    LocalDateTime monday = LocalDateTime.of(2024, 2, 26, 10, 0);
-
-    // 월요일, 화요일에 배변 기록 생성
-    createToilet(monday.withHour(8), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "월요일");
-    createToilet(
-        monday.plusDays(1).withHour(9),
-        true,
-        ToiletColor.DARK_BROWN,
-        ToiletShape.CORN,
-        15,
-        6,
-        "화요일");
-
-    given()
-        .header("Authorization", validJwtToken)
-        .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-        .get(weeklyUrl(monday.plusDays(4)))
-        .then()
-        .statusCode(HttpStatus.OK.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(200))
-        .body("data.defecationScore", notNullValue())
-        .body("data.userAverage", notNullValue());
-  }
-
-  // 8) 생활 기록은 많지만 배변 기록은 1일만 → 실패
-  @Test
-  @DisplayName("[E2E][weekly] 생활 기록 7일 + 배변 기록 1일 → 데이터 부족으로 리포트 생성 불가")
-  void givenManyActivityButOnlyOneToilet_whenGetWeeklyReport_thenFail() {
-    LocalDateTime monday = LocalDateTime.of(2024, 3, 4, 10, 0);
-
-    // 월~일 모두 생활 기록 생성 (7일)
-    for (int i = 0; i < 7; i++) {
-      createActivity(monday.plusDays(i));
-    }
-
-    // 배변 기록은 수요일에만 생성 (1일)
-    createToilet(
-        monday.plusDays(2).withHour(8),
-        true,
-        ToiletColor.DEFAULT,
-        ToiletShape.BANANA,
-        10,
-        5,
-        "수요일만");
-
-    given()
-        .header("Authorization", validJwtToken)
-        .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-        .get(weeklyUrl(monday.plusDays(3)))
-        .then()
-        .statusCode(HttpStatus.BAD_REQUEST.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(400));
-  }
-
-  // 9) 생활 기록은 없지만 배변 기록은 2일 → 성공
-  @Test
-  @DisplayName("[E2E][weekly] 생활 기록 없음 + 배변 기록 2일 → 정상 리포트 반환")
-  void givenNoActivityButTwoToilets_whenGetWeeklyReport_thenOk() {
-    LocalDateTime monday = LocalDateTime.of(2024, 3, 11, 10, 0);
-
-    // 생활 기록은 없음
-    // 배변 기록만 목요일, 금요일에 생성 (2일)
-    createToilet(
-        monday.plusDays(3).withHour(8),
-        true,
-        ToiletColor.DEFAULT,
-        ToiletShape.BANANA,
-        12,
-        5,
-        "목요일");
-    createToilet(
-        monday.plusDays(4).withHour(9), true, ToiletColor.GOLD, ToiletShape.CREAM, 8, 4, "금요일");
-
-    given()
-        .header("Authorization", validJwtToken)
-        .accept(MediaType.APPLICATION_JSON_VALUE)
-        .when()
-        .get(weeklyUrl(monday.plusDays(5)))
-        .then()
-        .statusCode(HttpStatus.OK.value())
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body("status", equalTo(200))
-        .body("data.defecationScore", notNullValue())
-        .body("data.userAverage", notNullValue());
   }
 }


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* 주간 리포트가 일간 리포트를 기준으로 생성되도록 변경
* 주간 평균 점수가 일간 리포트를 기준으로 계산되도록 변경
* 캡슐화를 높이기 위해 도메인 vo에서 계산을 수행하도록 변경
* 주간을 나타내는 WeekRange vo 추가

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **리팩토링**
  * 주간 보고서 생성 시스템 개선으로 더욱 안정적이고 효율적인 주 단위 기간 관리 구현
  * 보고서 데이터 처리 로직 및 API 개선

* **테스트**
  * 주간 보고서 생성 기능에 대한 통합 테스트 시나리오 개선 및 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->