### PR TITLE
Fix/배변 기록 못 쌌어요 색상/모양 null 처리

### DIFF
--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -23,6 +23,7 @@ import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletColorCount;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletEvaluationLevel;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPainDistribution;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletPeriodCount;
+import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletShapeCount;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletTimeDistribution;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
@@ -50,7 +51,13 @@ public class ToiletReportMapper {
             ToiletShape.PORRIDGE, "설사 주의",
             ToiletShape.WATER, "설사 주의");
 
-    // NONE인 경우를 제외하고 매핑
+    List<ToiletShapeCount> mostFrequentToiletShapes = report.getMostFrequentToiletShapes();
+
+    // 필터링 후 아무 유효한 모양이 없다면 “모양 평가 불가”
+    if (mostFrequentToiletShapes.isEmpty()) {
+      return new MonthlyShapeSection("이번 달에는 모양을 확인할 수 있는 배변 기록이 없어요", List.of());
+    }
+
     List<MonthlyToiletShape> items =
         report.getMostFrequentToiletShapes().stream()
             .map(
@@ -292,8 +299,8 @@ public class ToiletReportMapper {
                       new ToiletReportItem(
                           item.getOccurredAt().toDateTime(),
                           DETAIL_MESSAGE_MAP.get(dailyToiletReport.getLevel()),
-                          item.getColor(),
-                          item.getShape(),
+                          item.getColor() == ToiletColor.NONE ? null : item.getColor(),
+                          item.getShape() == ToiletShape.NONE ? null : item.getShape(),
                           item.getDuration(),
                           item.getPain(),
                           item.getNote()))

--- a/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
+++ b/src/main/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapper.java
@@ -5,8 +5,6 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import depromeet.lessonfour.server.common.api.code.ErrorCode;
-import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.DailyToiletReportDto;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletReportItem;
 import depromeet.lessonfour.server.report.api.dto.response.GetDailyReportResponseDto.ToiletSummary;
@@ -42,6 +40,7 @@ public class ToiletReportMapper {
   /** 배변 모양 섹션 매핑 */
   public MonthlyShapeSection mapShape(MonthlyReport report) {
     final String titleMessage = "이번 달 자주 본 배변 모양이에요";
+
     final Map<ToiletShape, String> MESSAGE_BY_SHAPE =
         Map.of(
             ToiletShape.RABBIT, "변비 주의",
@@ -51,6 +50,7 @@ public class ToiletReportMapper {
             ToiletShape.PORRIDGE, "설사 주의",
             ToiletShape.WATER, "설사 주의");
 
+    // NONE인 경우를 제외하고 매핑
     List<MonthlyToiletShape> items =
         report.getMostFrequentToiletShapes().stream()
             .map(
@@ -84,10 +84,9 @@ public class ToiletReportMapper {
 
     List<ToiletColorCount> colorCounts = report.getMostFrequentToiletColors();
 
-    // 색상 기록이 없는 경우 - 월별 2건 이상의 주간 리포트, 주별 2건 이상의 일간 리포트가 필요하므로 발생하지 않아야 함
+    // 필터링 후 아무 유효한 색상이 없다면 “색상 평가 불가”
     if (colorCounts.isEmpty()) {
-      log.error("Monthly toilet color report mapping failed - no color records found");
-      throw new ServerException(ErrorCode.INTERNAL_SERVER_ERROR);
+      return new MonthlyColorSection("이번 달에는 색상을 확인할 수 있는 배변 기록이 없어요", "", List.of());
     }
 
     // 색상 우선순위에 따라 정렬 (빈도수가 같으면 우선순위 높은 색상이 먼저)

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/MonthlyToiletReport.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/MonthlyToiletReport.java
@@ -76,6 +76,7 @@ public class MonthlyToiletReport {
             .flatMap(weeklyReport -> weeklyReport.getDailyReports().stream())
             .flatMap(dailyReport -> dailyReport.getItems().stream())
             .filter(evaluation -> evaluation.getShape() != null)
+            .filter(evaluation -> evaluation.getShape() != ToiletShape.NONE)
             .collect(Collectors.groupingBy(ToiletEvaluation::getShape, Collectors.counting()));
 
     return shapeCountMap.entrySet().stream()
@@ -92,6 +93,7 @@ public class MonthlyToiletReport {
             .flatMap(weeklyReport -> weeklyReport.getDailyReports().stream())
             .flatMap(dailyReport -> dailyReport.getItems().stream())
             .filter(evaluation -> evaluation.getColor() != null)
+            .filter(evaluation -> evaluation.getColor() != ToiletColor.NONE)
             .collect(Collectors.groupingBy(ToiletEvaluation::getColor, Collectors.counting()));
 
     return colorMap.entrySet().stream()

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/ToiletEvaluation.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/ToiletEvaluation.java
@@ -56,14 +56,24 @@ public class ToiletEvaluation {
     double score = BASE_SCORE;
 
     score += successScore(record.isSuccessful()) * SUCCESS_WEIGHT;
-    score += (record.getColor() != null ? record.getColor().getScore() : 0) * COLOR_WEIGHT;
-    score += (record.getShape() != null ? record.getShape().getScore() : 0) * SHAPE_WEIGHT;
     score += durationPenalty(record.getDuration()) * DURATION_WEIGHT;
     score += painPenalty(record.getPain()) * PAIN_WEIGHT;
+    score += record.getColor().getScore() * COLOR_WEIGHT;
+    score += record.getShape().getScore() * SHAPE_WEIGHT;
 
     double finalScore = normalizeScore(score);
 
-    return ToiletEvaluation.from(finalScore, ToiletEvaluationLevel.from(finalScore), record);
+    return ToiletEvaluation.builder()
+        .score(score)
+        .level(ToiletEvaluationLevel.from(finalScore))
+        .duration(record.getDuration())
+        .color(record.getColor())
+        .shape(record.getShape())
+        .pain(record.getPain())
+        .note(record.getNote())
+        .occurredAt(record.getActivityAt())
+        .isSuccess(record.isSuccessful())
+        .build();
   }
 
   private static double normalizeScore(double score) {
@@ -96,21 +106,6 @@ public class ToiletEvaluation {
       return -10;
     }
     return 0;
-  }
-
-  public static ToiletEvaluation from(
-      double score, ToiletEvaluationLevel level, ToiletRecord record) {
-    return ToiletEvaluation.builder()
-        .score(score)
-        .level(level)
-        .color(record.getColor())
-        .shape(record.getShape())
-        .duration(record.getDuration())
-        .pain(record.getPain())
-        .note(record.getNote())
-        .occurredAt(record.getActivityAt())
-        .isSuccess(record.isSuccessful())
-        .build();
   }
 
   public boolean failed() {

--- a/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/ToiletEvaluation.java
+++ b/src/main/java/depromeet/lessonfour/server/report/domain/vo/toilet/ToiletEvaluation.java
@@ -10,23 +10,34 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 성공한 배변은 높은 점수로 이어져야 한다.
+ *
+ * <p>실패한 배변도 통증/시간으로 인한 “나쁜 경험”을 반영해야 한다.
+ *
+ * <p>색/모양은 건강 척도이므로 성공한 배변에서만 평가해야 한다.
+ *
+ * <p>극단적인 입력에서도 점수가 0~100 범위에 자연스럽게 매핑되어야 한다.
+ *
+ * <p>“점수 하나로 사용자 상태를 간단히 설명”해야 하므로 직관적이어야 한다.
+ */
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 public class ToiletEvaluation {
 
   // 가중치
-  private static final int SUCCESS_WEIGHT = 5;
-  private static final int SHAPE_WEIGHT = 3;
-  private static final int COLOR_WEIGHT = 2;
-  private static final int DURATION_WEIGHT = 1;
-  private static final int PAIN_WEIGHT = 4;
+  private static final int SUCCESS_WEIGHT = 3;
+  private static final int SHAPE_WEIGHT = 2;
+  private static final int COLOR_WEIGHT = 3;
+  private static final int DURATION_WEIGHT = 2;
+  private static final int PAIN_WEIGHT = 5;
 
   // 기본 점수
-  private static final double BASE_SCORE = 50;
+  private static final double BASE_SCORE = 60;
 
   // 성공/실패 점수
-  private static final int SUCCESS_BONUS = 10;
-  private static final int FAIL_PENALTY = -20;
+  private static final int SUCCESS_BONUS = 5;
+  private static final int FAIL_PENALTY = -4;
 
   // 통증 threshold
   private static final int PAIN_SEVERE_THRESHOLD = 80;
@@ -58,13 +69,16 @@ public class ToiletEvaluation {
     score += successScore(record.isSuccessful()) * SUCCESS_WEIGHT;
     score += durationPenalty(record.getDuration()) * DURATION_WEIGHT;
     score += painPenalty(record.getPain()) * PAIN_WEIGHT;
-    score += record.getColor().getScore() * COLOR_WEIGHT;
-    score += record.getShape().getScore() * SHAPE_WEIGHT;
+
+    if (record.isSuccessful()) {
+      score += record.getColor().getScore() * COLOR_WEIGHT;
+      score += record.getShape().getScore() * SHAPE_WEIGHT;
+    }
 
     double finalScore = normalizeScore(score);
 
     return ToiletEvaluation.builder()
-        .score(score)
+        .score(finalScore)
         .level(ToiletEvaluationLevel.from(finalScore))
         .duration(record.getDuration())
         .color(record.getColor())
@@ -89,13 +103,13 @@ public class ToiletEvaluation {
   // 통증별 점수
   private static int painPenalty(int pain) {
     if (pain > PAIN_SEVERE_THRESHOLD) {
-      return -30;
+      return -5;
     }
     if (pain > PAIN_MODERATE_THRESHOLD) {
-      return -15;
+      return -3;
     }
     if (pain > PAIN_MILD_THRESHOLD) {
-      return -5;
+      return -1;
     }
     return 0;
   }
@@ -103,7 +117,7 @@ public class ToiletEvaluation {
   // 소요시간별 점수
   private static int durationPenalty(int minute) {
     if (minute > DURATION_LONG_THRESHOLD) {
-      return -10;
+      return -4;
     }
     return 0;
   }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
@@ -1,7 +1,9 @@
 package depromeet.lessonfour.server.toiletrecord.domain.entity;
 
+import depromeet.lessonfour.server.common.api.code.ErrorCode;
 import depromeet.lessonfour.server.common.domain.entity.BaseTimeEntity;
 import depromeet.lessonfour.server.common.domain.vo.ActivityAt;
+import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletColor;
 import depromeet.lessonfour.server.toiletrecord.domain.vo.ToiletShape;
 import depromeet.lessonfour.server.user.domain.entity.User;
@@ -85,11 +87,15 @@ public class ToiletRecord extends BaseTimeEntity {
       int duration,
       String note,
       ActivityAt activityAt) {
+
+    ToiletColor finalColor = isSuccessful ? color : ToiletColor.NONE;
+    ToiletShape finalShape = isSuccessful ? shape : ToiletShape.NONE;
+
     return ToiletRecord.builder()
         .user(user)
         .isSuccessful(isSuccessful)
-        .color(color)
-        .shape(shape)
+        .color(finalColor)
+        .shape(finalShape)
         .pain(pain)
         .duration(duration)
         .note(note)
@@ -107,12 +113,25 @@ public class ToiletRecord extends BaseTimeEntity {
       String note,
       ActivityAt activityAt) {
     if (isSuccessful != null) this.isSuccessful = isSuccessful;
-    if (color != null) this.color = color;
-    if (shape != null) this.shape = shape;
     if (pain != null) this.pain = pain;
     if (duration != null) this.duration = duration;
     if (note != null) this.note = note;
     if (activityAt != null) this.activityAt = activityAt;
+
+    if (this.isSuccessful) {
+      // 성공이라면 color/shape 반드시 필요
+      if (color != null) this.color = color;
+      if (shape != null) this.shape = shape;
+
+      if (this.color == null || this.shape == null) {
+        throw new ServerException(ErrorCode.INVALID_FIELD_ERROR);
+      }
+
+    } else {
+      // 실패라면 color/shape는 의미 없으므로 NONE으로 강제
+      this.color = ToiletColor.NONE;
+      this.shape = ToiletShape.NONE;
+    }
   }
 
   public void delete() {

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
@@ -88,6 +88,10 @@ public class ToiletRecord extends BaseTimeEntity {
       String note,
       ActivityAt activityAt) {
 
+    if (isSuccessful && (color == null || shape == null)) {
+      throw new ServerException(ErrorCode.INVALID_FIELD_ERROR);
+    }
+
     ToiletColor finalColor = isSuccessful ? color : ToiletColor.NONE;
     ToiletShape finalShape = isSuccessful ? shape : ToiletShape.NONE;
 

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/entity/ToiletRecord.java
@@ -127,7 +127,10 @@ public class ToiletRecord extends BaseTimeEntity {
       if (color != null) this.color = color;
       if (shape != null) this.shape = shape;
 
-      if (this.color == null || this.shape == null) {
+      if (this.color == null
+          || this.shape == null
+          || this.color == ToiletColor.NONE
+          || this.shape == ToiletShape.NONE) {
         throw new ServerException(ErrorCode.INVALID_FIELD_ERROR);
       }
 

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletColor.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletColor.java
@@ -19,9 +19,9 @@ public enum ToiletColor {
 
   public int getScore() {
     return switch (this) {
-      case DEFAULT, GOLD -> 0;
-      case DARK_BROWN -> -5;
-      case RED, GREEN, WHITE, BLACK -> -20; // 비정상
+      case DEFAULT, GOLD -> 3;
+      case DARK_BROWN -> -2;
+      case RED, GREEN, WHITE, BLACK -> -12; // 비정상
       case NONE -> 0; // 실패한 경우 점수에 영향 없음
     };
   }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletColor.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletColor.java
@@ -12,7 +12,8 @@ public enum ToiletColor {
   RED("적색"),
   GREEN("녹색"),
   WHITE("흰색"),
-  BLACK("흑색");
+  BLACK("흑색"),
+  NONE("실패");
 
   private final String value;
 
@@ -21,6 +22,7 @@ public enum ToiletColor {
       case DEFAULT, GOLD -> 0;
       case DARK_BROWN -> -5;
       case RED, GREEN, WHITE, BLACK -> -20; // 비정상
+      case NONE -> 0; // 실패한 경우 점수에 영향 없음
     };
   }
 }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
@@ -18,11 +18,8 @@ public enum ToiletShape {
 
   public int getScore() {
     return switch (this) {
-      case RABBIT -> -15;
-      case PORRIDGE -> -10; // 묽음
-      case CORN -> -5;
-      case CREAM, WATER -> 10;
-      case BANANA -> 15; // 이상적
+      case RABBIT, CORN, PORRIDGE, CREAM, WATER -> -5;
+      case BANANA -> 5; // 이상적
       case NONE -> 0; // 실패한 경우 점수에 영향 없음
     };
   }

--- a/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
+++ b/src/main/java/depromeet/lessonfour/server/toiletrecord/domain/vo/ToiletShape.java
@@ -11,7 +11,8 @@ public enum ToiletShape {
   BANANA("바나나"),
   CREAM("크림"),
   PORRIDGE("죽"),
-  WATER("물");
+  WATER("물"),
+  NONE("실패");
 
   public final String value;
 
@@ -22,6 +23,7 @@ public enum ToiletShape {
       case CORN -> -5;
       case CREAM, WATER -> 10;
       case BANANA -> 15; // 이상적
+      case NONE -> 0; // 실패한 경우 점수에 영향 없음
     };
   }
 }

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -157,9 +157,7 @@ class HomeE2ETest {
   @DisplayName("[home] 점수 85(VERY_GOOD) + 화장실 1건 + 활동없음 → hero=VERY_GOOD 이미지/컬러")
   void home_ok_veryGood() {
     LocalDate date = LocalDate.of(2024, 10, 6);
-    // score=85 → VERY_GOOD(80–100)
-    // 1개 기록: 50+50+0-15(CORN)+0+0 = 85
-    createToilet(LocalDateTime.of(2024, 10, 6, 8, 0), "DEFAULT", "CORN", 10, 5);
+    createToilet(LocalDateTime.of(2024, 10, 6, 8, 0), "GOLD", "BANANA", 10, 5);
 
     given()
         .header("Authorization", validJwtToken)
@@ -182,7 +180,7 @@ class HomeE2ETest {
     LocalDate date = LocalDate.of(2024, 10, 7);
     // score=15 → VERY_BAD(0–19)
     // 1개 기록: 50+50-40(RED)-45(RABBIT)+0+0 = 15
-    createToilet(LocalDateTime.of(2024, 10, 7, 8, 0), "RED", "RABBIT", 10, 5);
+    createToilet(LocalDateTime.of(2024, 10, 7, 8, 0), "RED", "RABBIT", 100, 15);
 
     given()
         .header("Authorization", validJwtToken)
@@ -201,9 +199,9 @@ class HomeE2ETest {
   @DisplayName("[home] 경계값 매핑 확인: 60(GOOD), 40(AVERAGE), 20(BAD)")
   void home_ok_boundaries() {
     // 60 → GOOD
-    // 기록: 50+50-10(DARK_BROWN)-30(PORRIDGE)+0+0 = 60
+    // 기록: 60 + 50 - 10(DARK_BROWN) - 30(PORRIDGE) + 0 + 0 = 60
     LocalDate d1 = LocalDate.of(2024, 10, 8);
-    createToilet(LocalDateTime.of(2024, 10, 8, 8, 0), "DARK_BROWN", "PORRIDGE", 10, 5);
+    createToilet(LocalDateTime.of(2024, 10, 8, 8, 0), "DARK_BROWN", "BANANA", 10, 5);
     given()
         .header("Authorization", validJwtToken)
         .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/recordquery/api/HomeE2ETest.java
@@ -127,10 +127,6 @@ class HomeE2ETest {
   @DisplayName("[home] 점수 75(GOOD) + 화장실 2건 + 활동존재 → hero=GOOD 이미지/컬러")
   void home_ok_good() {
     LocalDate date = LocalDate.of(2024, 10, 5);
-    // score=75 → GOOD(60–79)
-    // 2개 기록의 평균: (85+65)/2 = 75
-    // 기록1: 50+50+0-15(CORN)+0+0 = 85
-    // 기록2: 50+50+0-15(CORN)+0-20(통증25) = 65
     createToilet(LocalDateTime.of(2024, 10, 5, 8, 0), "DEFAULT", "CORN", 10, 5);
     createToilet(LocalDateTime.of(2024, 10, 5, 14, 0), "DEFAULT", "CORN", 25, 5);
 
@@ -178,8 +174,6 @@ class HomeE2ETest {
   @DisplayName("[home] 점수 15(VERY_BAD) → hero=VERY_BAD 이미지/컬러")
   void home_ok_veryBad() {
     LocalDate date = LocalDate.of(2024, 10, 7);
-    // score=15 → VERY_BAD(0–19)
-    // 1개 기록: 50+50-40(RED)-45(RABBIT)+0+0 = 15
     createToilet(LocalDateTime.of(2024, 10, 7, 8, 0), "RED", "RABBIT", 100, 15);
 
     given()
@@ -198,8 +192,7 @@ class HomeE2ETest {
   @Test
   @DisplayName("[home] 경계값 매핑 확인: 60(GOOD), 40(AVERAGE), 20(BAD)")
   void home_ok_boundaries() {
-    // 60 → GOOD
-    // 기록: 60 + 50 - 10(DARK_BROWN) - 30(PORRIDGE) + 0 + 0 = 60
+    // GOOD
     LocalDate d1 = LocalDate.of(2024, 10, 8);
     createToilet(LocalDateTime.of(2024, 10, 8, 8, 0), "DARK_BROWN", "BANANA", 10, 5);
     given()
@@ -212,8 +205,7 @@ class HomeE2ETest {
         .body("data.heroImage", containsString("toilet/good.png"))
         .body("data.heroBackgroundColors", hasItems("#134DB1", "#588DFF"));
 
-    // 40 → AVERAGE
-    // 기록: 50+50-10(DARK_BROWN)-30(PORRIDGE)-20(통증25)+0 = 40
+    // AVERAGE
     LocalDate d2 = LocalDate.of(2024, 10, 9);
     createToilet(LocalDateTime.of(2024, 10, 9, 8, 0), "DARK_BROWN", "PORRIDGE", 25, 5);
     given()
@@ -226,8 +218,7 @@ class HomeE2ETest {
         .body("data.heroImage", containsString("toilet/normal.png"))
         .body("data.heroBackgroundColors", hasItems("#2B42B4", "#8F58FF"));
 
-    // 20 → BAD
-    // 기록: 50+50-40(RED)-30(PORRIDGE)+0-10(시간15분) = 20
+    // BAD
     LocalDate d3 = LocalDate.of(2024, 10, 10);
     createToilet(LocalDateTime.of(2024, 10, 10, 8, 0), "RED", "PORRIDGE", 10, 15);
     given()
@@ -346,7 +337,6 @@ class HomeE2ETest {
         .statusCode(HttpStatus.OK.value());
 
     // 다른 사용자의 배변 기록은 자동으로 점수 계산됨
-    // 기록: 50+50+0+45(BANANA)+0+0 = 145 (capped at 100, VERY_GOOD)
 
     // 현재 사용자로 조회 → 0/false + hero는 기본(점수 없으면 AVERAGE로 매핑됨)
     given()

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportE2ETest.java
@@ -189,17 +189,25 @@ class GetDailyReportE2ETest {
         .body("data.stress", notNullValue());
   }
 
-  // 4) toiletrecord 여러개: isSuccessful=false, color=null, shape=null 섞임
+  // 4) toiletrecord 여러개: isSuccessful=false
   @Test
   @DisplayName("[E2E] toiletrecord 다건(실패/색상null/모양null 포함) → NPE 없이 정상 반환")
   void givenMultipleToiletWithNullsAndFailure_whenGetDailyReport_thenOk() {
     LocalDateTime base = LocalDateTime.of(2024, 1, 18, 10, 0);
 
     createToilet(base.withHour(7), true, ToiletColor.DEFAULT, ToiletShape.BANANA, 10, 5, "ok");
-    createToilet(base.withHour(9), false, ToiletColor.DEFAULT, ToiletShape.CORN, 30, 12, "fail");
-    createToilet(base.withHour(12), true, null, ToiletShape.CREAM, 5, 3, null); // color null
-    createToilet(base.withHour(18), true, ToiletColor.DARK_BROWN, null, 0, 2, null); // shape null
-    createToilet(base.withHour(20), true, null, null, 25, 8, "둘다 null"); // both null
+    createToilet(base.withHour(9), false, ToiletColor.NONE, ToiletShape.NONE, 30, 12, "fail");
+    createToilet(
+        base.withHour(12), true, ToiletColor.DEFAULT, ToiletShape.CREAM, 5, 3, null); // color null
+    createToilet(
+        base.withHour(18),
+        true,
+        ToiletColor.DARK_BROWN,
+        ToiletShape.BANANA,
+        0,
+        2,
+        null); // shape null
+    createToilet(base.withHour(20), false, null, null, 25, 8, "둘다 null"); // both null
 
     given()
         .header("Authorization", validJwtToken)

--- a/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportToiletDetailMessageE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/GetDailyReportToiletDetailMessageE2ETest.java
@@ -128,8 +128,11 @@ class GetDailyReportToiletDetailMessageE2ETest {
   /**
    * VERY_BAD (0~19점) 테스트
    *
-   * <p>점수 계산: BASE: 50 실패: -100 (FAIL_PENALTY * SUCCESS_WEIGHT = -20 * 5) 총점: 50 - 100 = -50 → 정규화
-   * 후 0점
+   * <p>점수 계산: BASE: 60 실패: -20 (FAIL_PENALTY * SUCCESS_WEIGHT = -4 * 5) 총점: 50 - 100 = -50 → 정규화
+   * <li>기본 점수 : 60
+   * <li>실패 패널티 : -20
+   * <li>통증 패널티 : -30
+   * <li>소요 시간 패널티 : -10 총점: 60 - 20 - 30 - 10 = 0점 (VERY_BAD)
    */
   @Test
   @DisplayName(
@@ -140,11 +143,11 @@ class GetDailyReportToiletDetailMessageE2ETest {
     // VERY_BAD를 만들기 위한 조건: 실패 케이스
     createToilet(
         base.withHour(8),
-        false, // 실패 → -100점
-        ToiletColor.DEFAULT,
-        ToiletShape.BANANA,
-        10, // 낮은 통증
-        5, // 짧은 시간
+        false,
+        ToiletColor.NONE,
+        ToiletShape.NONE,
+        100, // 낮은 통증
+        15, // 짧은 시간
         "실패");
 
     given()
@@ -163,9 +166,11 @@ class GetDailyReportToiletDetailMessageE2ETest {
 
   /**
    * BAD (20~39점) 테스트
-   *
-   * <p>점수 계산: BASE: 50 성공: +50 색상(BLACK): -20 * 2 = -40 모양(CORN): -5 * 3 = -15 통증(30): -5 * 4 = -20
-   * 총점: 50 + 50 - 40 - 15 - 20 = 25점 (BAD)
+   * <li>기본 점수 : 60
+   * <li>실패 점수 : -4 * 5 = -20
+   * <li>소요 시간 패널티 : -5 * 2 = -10
+   * <li>통증 패널티 : -1 * 5 = -5
+   * <li>총점: 60 - 20 - 10 - 5 = 25점 (BAD)
    */
   @Test
   @DisplayName(
@@ -176,11 +181,11 @@ class GetDailyReportToiletDetailMessageE2ETest {
     // BAD를 만들기 위한 조건: 성공 + 나쁜 색상 + 나쁜 모양 + 중간 통증
     createToilet(
         base.withHour(8),
-        true, // 성공 → +50점
-        ToiletColor.BLACK, // 나쁜 색상 → -40점
-        ToiletShape.CORN, // 나쁜 모양 → -15점
-        30, // 중간 통증 → -20점
-        5, // 짧은 시간
+        false, // 성공 → +60점
+        ToiletColor.NONE,
+        ToiletShape.NONE,
+        21,
+        15,
         "BAD");
 
     given()
@@ -201,7 +206,8 @@ class GetDailyReportToiletDetailMessageE2ETest {
    * AVERAGE (40~59점) 테스트
    *
    * <p>점수 계산: BASE: 50 성공: +50 색상(DARK_BROWN): -5 * 2 = -10 모양(RABBIT): -15 * 3 = -45 총점: 50 + 50 -
-   * 10 - 45 = 45점 (AVERAGE)
+   * 10 - 45 = 45점 (AVERAGE) 기본 점수 : 60 성공 점수 : +25 색상 점수 : -3 * 3 = -9 모양 점수 : 5 * 3 = -15 통증 점수 :
+   * -1 * 5 = -5 소요 시간 점수 : 0
    */
   @Test
   @DisplayName(
@@ -212,9 +218,9 @@ class GetDailyReportToiletDetailMessageE2ETest {
     // AVERAGE를 만들기 위한 조건: 성공 + 나쁜 색상 + 나쁜 모양
     createToilet(
         base.withHour(8),
-        true, // 성공 → +50점
-        ToiletColor.DARK_BROWN, // 나쁜 색상 → -10점
-        ToiletShape.RABBIT, // 나쁜 모양 → -45점
+        true,
+        ToiletColor.DARK_BROWN,
+        ToiletShape.RABBIT,
         10, // 낮은 통증
         5, // 짧은 시간
         "AVERAGE");
@@ -249,7 +255,7 @@ class GetDailyReportToiletDetailMessageE2ETest {
     createToilet(
         base.withHour(8),
         true, // 성공 → +50점
-        ToiletColor.DARK_BROWN, // 약간 나쁜 색상 → -10점
+        ToiletColor.GOLD, // 약간 나쁜 색상 → -10점
         ToiletShape.CORN, // 약간 나쁜 모양 → -15점
         10, // 낮은 통증
         5, // 짧은 시간

--- a/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperColorTest.java
+++ b/src/test/java/depromeet/lessonfour/server/report/api/mapper/toilet/ToiletReportMapperColorTest.java
@@ -1,7 +1,6 @@
 package depromeet.lessonfour.server.report.api.mapper.toilet;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,8 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import depromeet.lessonfour.server.common.api.code.ErrorCode;
-import depromeet.lessonfour.server.common.exception.ServerException;
 import depromeet.lessonfour.server.report.api.dto.response.GetMonthlyReportResponseDto.MonthlyColorSection;
 import depromeet.lessonfour.server.report.domain.vo.MonthlyReport;
 import depromeet.lessonfour.server.report.domain.vo.toilet.ToiletColorCount;
@@ -167,10 +164,13 @@ class ToiletReportMapperColorTest {
     // given
     when(mockReport.getMostFrequentToiletColors()).thenReturn(Collections.emptyList());
 
-    // when & then
-    assertThatThrownBy(() -> mapper.mapColor(mockReport))
-        .isInstanceOf(ServerException.class)
-        .hasFieldOrPropertyWithValue("baseErrorCode", ErrorCode.INTERNAL_SERVER_ERROR);
+    // when
+    MonthlyColorSection result = mapper.mapColor(mockReport);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.titleMessage()).isEqualTo("이번 달에는 색상을 확인할 수 있는 배변 기록이 없어요");
+    assertThat(result.colorMessage()).isEmpty();
   }
 
   @Test

--- a/src/test/java/depromeet/lessonfour/server/toiletrecord/api/UpdateToiletRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/toiletrecord/api/UpdateToiletRecordE2ETest.java
@@ -110,8 +110,6 @@ class UpdateToiletRecordE2ETest {
         """
         {
           "isSuccessful": false,
-          "color": "RED",
-          "shape": "CORN",
           "pain": 50,
           "duration": 12,
           "note": "수정된 배변 기록"
@@ -131,8 +129,8 @@ class UpdateToiletRecordE2ETest {
         .body("message", equalTo("업데이트가 완료되었습니다."))
         .body("data.id", equalTo(toiletRecordId.intValue()))
         .body("data.isSuccessful", equalTo(false))
-        .body("data.color", equalTo("RED"))
-        .body("data.shape", equalTo("CORN"))
+        .body("data.color", equalTo("NONE"))
+        .body("data.shape", equalTo("NONE"))
         .body("data.pain", equalTo(50))
         .body("data.duration", equalTo(12))
         .body("data.note", equalTo("수정된 배변 기록"));

--- a/src/test/java/depromeet/lessonfour/server/toiletrecord/api/controller/UpdateToiletRecordE2ETest.java
+++ b/src/test/java/depromeet/lessonfour/server/toiletrecord/api/controller/UpdateToiletRecordE2ETest.java
@@ -61,15 +61,19 @@ class UpdateToiletRecordE2ETest {
   }
 
   private int createToiletRecord(
-      LocalDateTime occurredAt, boolean isSuccessful, int pain, int duration) {
-    // LinkedHashMap을 써서 직렬화 시 필드 순서를 고정(가독성용)
+      LocalDateTime occurredAt,
+      boolean isSuccessful,
+      int pain,
+      int duration,
+      String toiletColor,
+      String toiletShape) {
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("occurredAt", occurredAt.format(DT));
     body.put("isSuccessful", isSuccessful);
-    // color/shape 생략 → null 허용 검증
+    body.put("color", toiletColor);
+    body.put("shape", toiletShape);
     body.put("pain", pain);
     body.put("duration", duration);
-    // note 생략
 
     return given()
         .header("Authorization", token)
@@ -79,33 +83,144 @@ class UpdateToiletRecordE2ETest {
         .post("/api/v1/poo-records")
         .then()
         .statusCode(HttpStatus.OK.value())
-        // 응답 바디의 status(비즈니스 코드)는 201
         .body("status", equalTo(201))
         .body("data.id", notNullValue())
-        .body("data.userId", equalTo(me.getId().intValue()))
-        .body("data.occurredAt", notNullValue())
-        .body("data.isSuccessful", equalTo(isSuccessful))
-        .body("data.color", nullValue())
-        .body("data.shape", nullValue())
-        .body("data.pain", equalTo(pain))
-        .body("data.duration", equalTo(duration))
         .extract()
         .path("data.id");
   }
 
+  private int createSuccessfulToiletRecord(
+      LocalDateTime occurredAt, int pain, int duration, String toiletColor, String toiletShape) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", occurredAt.format(DT));
+    body.put("isSuccessful", true);
+    body.put("color", toiletColor);
+    body.put("shape", toiletShape);
+    body.put("pain", pain);
+    body.put("duration", duration);
+
+    return given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.id", notNullValue())
+        .body("data.isSuccessful", equalTo(true))
+        .body("data.color", equalTo(toiletColor))
+        .body("data.shape", equalTo(toiletShape))
+        .extract()
+        .path("data.id");
+  }
+
+  private int createUnsuccessfulToiletRecord(LocalDateTime occurredAt, int pain, int duration) {
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", occurredAt.format(DT));
+    body.put("isSuccessful", false);
+    body.put("color", null);
+    body.put("shape", null);
+    body.put("pain", pain);
+    body.put("duration", duration);
+
+    return given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(201))
+        .body("data.id", notNullValue())
+        .body("data.isSuccessful", equalTo(false))
+        .body("data.color", nullValue())
+        .body("data.shape", nullValue())
+        .extract()
+        .path("data.id");
+  }
+
+  // ==== 생성 테스트: isSuccessful = true 케이스 ====
   @Test
-  @DisplayName("생성: color/shape를 생략해도(=null) 성공한다")
-  void create_withoutColorShape_success() {
-    createToiletRecord(LocalDateTime.of(2024, 7, 1, 8, 30), true, 10, 5);
+  @DisplayName("성공적인 배변 기록 요청 시 color가 null이면 400 에러를 반환한다")
+  void givenSuccessfulRecordRequest_whenColorIsNull_thenReturnsBadRequest() {
+    // given
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", LocalDateTime.of(2024, 7, 1, 8, 30).format(DT));
+    body.put("isSuccessful", true);
+    body.put("color", null);
+    body.put("shape", "BANANA");
+    body.put("pain", 10);
+    body.put("duration", 5);
+
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
   }
 
   @Test
-  @DisplayName("부분수정: note만 수정(다른 필드 미포함) 가능")
-  void patch_partial_update_note_only() {
-    int id = createToiletRecord(LocalDateTime.of(2024, 7, 2, 9, 0), true, 5, 7);
+  @DisplayName("성공적인 배변 기록 요청 시 shape가 null이면 400 에러를 반환한다")
+  void givenSuccessfulRecordRequest_whenShapeIsNull_thenReturnsBadRequest() {
+    // given
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", LocalDateTime.of(2024, 7, 1, 8, 30).format(DT));
+    body.put("isSuccessful", true);
+    body.put("color", "GOLD");
+    body.put("shape", null);
+    body.put("pain", 10);
+    body.put("duration", 5);
 
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("성공적인 배변 기록 요청 시 color와 shape가 모두 null이면 400 에러를 반환한다")
+  void givenSuccessfulRecordRequest_whenColorAndShapeAreNull_thenReturnsBadRequest() {
+    // given
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", LocalDateTime.of(2024, 7, 1, 8, 30).format(DT));
+    body.put("isSuccessful", true);
+    body.put("color", null);
+    body.put("shape", null);
+    body.put("pain", 10);
+    body.put("duration", 5);
+
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .when()
+        .post("/api/v1/poo-records")
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("기존 배변 기록이 있을 때 note만 수정하면 부분 수정에 성공한다")
+  void givenExistingRecord_whenPatchingNoteOnly_thenUpdatesSuccessfully() {
+    // given
+    int id =
+        createSuccessfulToiletRecord(LocalDateTime.of(2024, 7, 3, 10, 0), 20, 10, "GOLD", "BANANA");
     var patchBody = Map.of("note", "after breakfast");
 
+    // when & then
     given()
         .header("Authorization", token)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -116,42 +231,45 @@ class UpdateToiletRecordE2ETest {
         .statusCode(HttpStatus.OK.value())
         .body("status", equalTo(200))
         .body("data.id", equalTo(id))
-        .body("data.userId", equalTo(me.getId().intValue()))
-        .body("data.note", equalTo("after breakfast"));
-  }
-
-  @Test
-  @DisplayName("부분수정: 나중에 color/shape 채워 넣어도 된다")
-  void patch_fill_color_shape_later() {
-    int id = createToiletRecord(LocalDateTime.of(2024, 7, 3, 10, 0), true, 20, 10);
-
-    var patchBody =
-        Map.of(
-            "color", "DEFAULT",
-            "shape", "BANANA");
-
-    given()
-        .header("Authorization", token)
-        .contentType(MediaType.APPLICATION_JSON_VALUE)
-        .body(patchBody)
-        .when()
-        .patch("/api/v1/poo-records/{id}", id)
-        .then()
-        .statusCode(HttpStatus.OK.value())
-        .body("status", equalTo(200))
-        .body("data.id", equalTo(id))
-        .body("data.userId", equalTo(me.getId().intValue()))
-        .body("data.color", equalTo("DEFAULT"))
+        .body("data.note", equalTo("after breakfast"))
+        .body("data.color", equalTo("GOLD"))
         .body("data.shape", equalTo("BANANA"));
   }
 
   @Test
-  @DisplayName("유효하지 않은 enum 값이면 400을 반환한다")
-  void patch_invalid_enum_returns_400() {
-    int id = createToiletRecord(LocalDateTime.of(2024, 7, 4, 11, 0), false, 0, 5);
+  @DisplayName("기존 배변 기록이 있을 때 color와 shape를 수정하면 수정에 성공한다")
+  void givenExistingRecord_whenPatchingColorAndShape_thenUpdatesSuccessfully() {
+    // given
+    int id =
+        createSuccessfulToiletRecord(LocalDateTime.of(2024, 7, 3, 10, 0), 20, 10, "GOLD", "BANANA");
+    var patchBody =
+        Map.of(
+            "color", "DEFAULT",
+            "shape", "CORN");
 
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(patchBody)
+        .when()
+        .patch("/api/v1/poo-records/{id}", id)
+        .then()
+        .statusCode(HttpStatus.OK.value())
+        .body("status", equalTo(200))
+        .body("data.color", equalTo("DEFAULT"))
+        .body("data.shape", equalTo("CORN"));
+  }
+
+  @Test
+  @DisplayName("기존 배변 기록이 있을 때 유효하지 않은 color 값으로 수정하면 400 에러를 반환한다")
+  void givenExistingRecord_whenPatchingWithInvalidColor_thenReturnsBadRequest() {
+    // given
+    int id =
+        createSuccessfulToiletRecord(LocalDateTime.of(2024, 7, 4, 11, 0), 0, 5, "GOLD", "BANANA");
     var patchBody = Map.of("color", "NOT_A_COLOR");
 
+    // when & then
     given()
         .header("Authorization", token)
         .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -160,5 +278,86 @@ class UpdateToiletRecordE2ETest {
         .patch("/api/v1/poo-records/{id}", id)
         .then()
         .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("기존 배변 기록이 있을 때 유효하지 않은 shape 값으로 수정하면 400 에러를 반환한다")
+  void givenExistingRecord_whenPatchingWithInvalidShape_thenReturnsBadRequest() {
+    // given
+    int id =
+        createSuccessfulToiletRecord(LocalDateTime.of(2024, 7, 4, 11, 0), 0, 5, "GOLD", "BANANA");
+    var patchBody = Map.of("shape", "NOT_A_SHAPE");
+
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(patchBody)
+        .when()
+        .patch("/api/v1/poo-records/{id}", id)
+        .then()
+        .statusCode(HttpStatus.BAD_REQUEST.value());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 기록 ID로 수정 요청하면 404 에러를 반환한다")
+  void givenNonExistentRecordId_whenPatching_thenReturnsNotFound() {
+    // given
+    int nonExistentId = 99999;
+    var patchBody = Map.of("note", "test note");
+
+    // when & then
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(patchBody)
+        .when()
+        .patch("/api/v1/poo-records/{id}", nonExistentId)
+        .then()
+        .statusCode(HttpStatus.NOT_FOUND.value());
+  }
+
+  @Test
+  @DisplayName("다른 사용자의 기록을 수정하려고 하면 404 에러를 반환한다")
+  void givenOtherUsersRecord_whenPatching_thenReturnsNotFound() {
+    // given - 다른 사용자 생성
+    User otherUser =
+        userRepository.save(
+            User.register("other@example.com", "other-user", passwordEncoder.encode("pw1234")));
+    String otherToken =
+        "Bearer " + jwtTokenGenerator.generateAccessToken(AccountContext.of(otherUser));
+
+    // 다른 사용자의 기록 생성
+    Map<String, Object> body = new LinkedHashMap<>();
+    body.put("occurredAt", LocalDateTime.of(2024, 7, 5, 10, 0).format(DT));
+    body.put("isSuccessful", true);
+    body.put("color", "GOLD");
+    body.put("shape", "BANANA");
+    body.put("pain", 10);
+    body.put("duration", 5);
+
+    int otherUserId =
+        given()
+            .header("Authorization", otherToken)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(body)
+            .when()
+            .post("/api/v1/poo-records")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .path("data.id");
+
+    // when & then - 현재 사용자가 다른 사용자의 기록 수정 시도
+    var patchBody = Map.of("note", "hacking attempt");
+
+    given()
+        .header("Authorization", token)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .body(patchBody)
+        .when()
+        .patch("/api/v1/poo-records/{id}", otherUserId)
+        .then()
+        .statusCode(HttpStatus.NOT_FOUND.value());
   }
 }


### PR DESCRIPTION
## Related Issue 🔗
<!-- 관련 이슈 번호를 적어주세요 -->
- closes #번호

## Summary 📝
* enum 값 추가로 npe 방지
* 못 쌌어요를 고려하여 colorMap에서 500에러를 던지지 않도록 수정

## Changes ✨
<!-- 구체적인 코드/설정/구조 변경 사항을 나열해주세요 -->

## Why we need 💡
<!-- 이 변경이 필요한 이유와 배경을 설명해주세요 -->

## Test 🧪
<!-- 테스트 방법과 결과를 작성해주세요 -->

## Trouble Shooting 🐛
<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## ScreenShot 📷
<!-- 스크린샷 첨부 -->

## To Reviewers 🙏
<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->

## CC 👥
<!-- 함께 알림을 받아야 하는 사람을 멘션해주세요 (@username) -->

## Anything else? 💬
<!-- 추가로 공유하고 싶은 내용, 참고 자료 링크 등을 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 실패한 기록은 색상·모양이 일관되게 NONE으로 표기되어 조회·업데이트 결과가 안정화됩니다.
  * 색상·모양이 없는 월간/일간 집계에서 예외 대신 사용자 안내 메시지와 빈 항목을 반환합니다.
  * 점수 산출 가중치와 보정값 조정으로 일간/월간 점수 및 상세 메시지 계산이 정확해집니다.

* **Refactor**
  * 빈 상태 처리와 실패 케이스를 우아하게 처리하도록 매핑 로직이 개선되었습니다.

* **Tests**
  * E2E 및 단위 테스트가 새로운 점수 기준과 빈 상태 처리 흐름에 맞춰 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->